### PR TITLE
Add test to validate behavior when using getbykey

### DIFF
--- a/src/backend/Csrs.Api/Repositories/DynamicsExtensions.cs
+++ b/src/backend/Csrs.Api/Repositories/DynamicsExtensions.cs
@@ -39,7 +39,7 @@ namespace Csrs.Interfaces.Dynamics
             try
             {
                 List<string> select = new() { "ssg_csrsfileid" };
-                _ = await dynamicsClient.Ssgcsrsfiles.GetByKeyAsync(id, select: select, cancellationToken: CancellationToken.None);
+                _ = await dynamicsClient.Ssgcsrsfiles.GetByKeyAsync(id, select: select, cancellationToken: cancellationToken);
                 return true;
             }
             catch (HttpOperationException exception) when (exception.Response?.StatusCode == HttpStatusCode.NotFound)

--- a/src/backend/Csrs.Interfaces.Dynamics/Csrs.Interfaces.Dynamics.csproj
+++ b/src/backend/Csrs.Interfaces.Dynamics/Csrs.Interfaces.Dynamics.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="StronglyTypedId" Version="1.0.0-beta05" PrivateAssets="all" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <Target Name="PostClean" AfterTargets="Clean">

--- a/src/backend/Csrs.Interfaces.Dynamics/Extensions/DynamicsClient.cs
+++ b/src/backend/Csrs.Interfaces.Dynamics/Extensions/DynamicsClient.cs
@@ -103,11 +103,15 @@ public partial class DynamicsClient
 
     public string GetEntityURI(string entityType, string id)
     {
-        string result = "";
-        if (id != null)
-        {            
-            result = BaseUri + entityType + "(" + id.Trim() + ")";
+        ArgumentNullException.ThrowIfNull(entityType);
+        ArgumentNullException.ThrowIfNull(id);
+
+        if (!Guid.TryParse(id, out Guid key))
+        {
+            throw new FormatException("Entity id is not a valid guid");
         }
-        return result;
+
+        string uri = BaseUri + entityType + "(" + key.ToString("d") + ")";
+        return uri;
     }
 }

--- a/src/backend/Csrs.Interfaces.Dynamics/Extensions/IDynamicsClient.cs
+++ b/src/backend/Csrs.Interfaces.Dynamics/Extensions/IDynamicsClient.cs
@@ -6,5 +6,51 @@ public partial interface IDynamicsClient
 {
     Task<PicklistOptionSetMetadata> GetPicklistOptionSetMetadataAsync(string entityName, string attributeName, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Gets the entity reference.
+    /// </summary>
+    /// <param name="entityType"></param>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException">if <paramref name="entityType"/> or <paramref name="id"/> is null.</exception>
+    /// <exception cref="FormatException"><paramref name="id"/> cannot be parsed as a <see cref="System.Guid"/></exception>
     string GetEntityURI(string entityType, string id);
+
+    /// <summary>
+    /// Gets the entity reference for a SSG CSRS BC Court Level
+    /// </summary>
+    /// <param name="entity">The entity to get reference for</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"><paramref name="entity"/> or <see cref="MicrosoftDynamicsCRMssgCsrsbccourtlevel.SsgCsrsbccourtlevelid"/> is null.</exception>
+    /// <exception cref="FormatException"><see cref="MicrosoftDynamicsCRMssgCsrsbccourtlevel.SsgCsrsbccourtlevelid"/> cannot be parsed as a <see cref="System.Guid"/></exception>
+    string GetEntityReference(MicrosoftDynamicsCRMssgCsrsbccourtlevel entity) => GetEntityURI("ssg_csrsbccourtlevels", entity?.SsgCsrsbccourtlevelid!);
+
+    /// <summary>
+    /// Gets the entity reference for a SSG CSRS File
+    /// </summary>
+    /// <param name="entity">The entity to get reference for</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"><paramref name="entity"/> or <see cref="MicrosoftDynamicsCRMssgCsrsfile.SsgCsrsfileid"/> is null.</exception>
+    /// <exception cref="FormatException"><see cref="MicrosoftDynamicsCRMssgCsrsfile.SsgCsrsfileid"/> cannot be parsed as a <see cref="System.Guid"/></exception>
+    string GetEntityReference(MicrosoftDynamicsCRMssgCsrsfile entity) => GetEntityURI("ssg_csrsfiles", entity?.SsgCsrsfileid!);
+    string GetEntityReference(FileId entity) => GetEntityURI("ssg_csrsfiles", entity.ToString());
+
+    /// <summary>
+    /// Gets the entity reference for a SSG CSRS Party
+    /// </summary>
+    /// <param name="entity">The entity to get reference for</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"><paramref name="entity"/> or <see cref="MicrosoftDynamicsCRMssgCsrsparty.SsgCsrspartyid"/> is null.</exception>
+    /// <exception cref="FormatException"><see cref="MicrosoftDynamicsCRMssgCsrsparty.SsgCsrspartyid"/> cannot be parsed as a <see cref="System.Guid"/></exception>
+    string GetEntityReference(MicrosoftDynamicsCRMssgCsrsparty entity) => GetEntityURI("ssg_csrsparties", entity?.SsgCsrspartyid!);
+    string GetEntityReference(PartyId entity) => GetEntityURI("ssg_csrsparties", entity.ToString());
+
+    /// <summary>
+    /// Gets the entity reference for a SSG CSRS BC Court Location
+    /// </summary>
+    /// <param name="entity">The entity to get reference for</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"><paramref name="entity"/> or <see cref="MicrosoftDynamicsCRMssgIjssbccourtlocation.SsgIjssbccourtlocationid"/> is null.</exception>
+    /// <exception cref="FormatException"><see cref="MicrosoftDynamicsCRMssgIjssbccourtlocation.SsgIjssbccourtlocationid"/> cannot be parsed as a <see cref="System.Guid"/></exception>
+    string GetEntityReference(MicrosoftDynamicsCRMssgIjssbccourtlocation entity) => GetEntityURI("ssg_ijssbccourtlocations", entity?.SsgIjssbccourtlocationid!);
 }

--- a/src/backend/Csrs.Interfaces.Dynamics/ModelExtensions/FileId.cs
+++ b/src/backend/Csrs.Interfaces.Dynamics/ModelExtensions/FileId.cs
@@ -1,0 +1,9 @@
+﻿using StronglyTypedIds;
+
+namespace Csrs.Interfaces.Dynamics.Models
+{
+    [StronglyTypedId()]
+    public partial struct FileId
+    {
+    }
+}

--- a/src/backend/Csrs.Interfaces.Dynamics/ModelExtensions/PartyId.cs
+++ b/src/backend/Csrs.Interfaces.Dynamics/ModelExtensions/PartyId.cs
@@ -1,0 +1,9 @@
+﻿using StronglyTypedIds;
+
+namespace Csrs.Interfaces.Dynamics.Models
+{
+    [StronglyTypedId()]
+    public partial struct PartyId
+    {
+    }
+}

--- a/src/backend/Csrs.Test/Interfaces/Dynamics/Models/FileIdTest.cs
+++ b/src/backend/Csrs.Test/Interfaces/Dynamics/Models/FileIdTest.cs
@@ -1,0 +1,33 @@
+﻿using Csrs.Interfaces.Dynamics.Models;
+using System;
+using Xunit;
+
+
+namespace Csrs.Test.Interfaces.Dynamics.Models
+{
+    public class FileIdTest
+    {
+        [Fact]
+        public void should_format_with_d_format_specifier_using_new()
+        {
+            FileId sut = FileId.New();
+
+            var expected = sut.Value.ToString("d");
+            var actual = sut.ToString();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void should_format_with_d_format_specifier_using_guid()
+        {
+            var id = Guid.NewGuid();
+            FileId sut = new FileId(id);
+
+            var expected = id.ToString("d");
+            var actual = sut.ToString();
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/backend/Csrs.TntegrationTest/GetFileTest.cs
+++ b/src/backend/Csrs.TntegrationTest/GetFileTest.cs
@@ -1,7 +1,9 @@
 ﻿using Csrs.Interfaces.Dynamics;
 using Csrs.Interfaces.Dynamics.Models;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -10,6 +12,23 @@ namespace Csrs.TntegrationTest
 {
     public class GetFileTest : DynamicsClientTestBase
     {
+        [DebugOnlyFact]
+        public async Task get_entity_that_does_not_exist_throws_HttpOperationException_with_response_status_code_of_NotFound()
+        {
+            IDynamicsClient dynamicsClient = _serviceProvider.GetRequiredService<IDynamicsClient>();
+
+            var actual = await Assert.ThrowsAsync<Microsoft.Rest.HttpOperationException>(async () =>
+                {
+                    string key = Guid.NewGuid().ToString("d");
+                    List<string> select = new List<string> { "ssg_csrsfileid" };
+                    await dynamicsClient.Ssgcsrsfiles.GetByKeyAsync(key, select: select, cancellationToken: CancellationToken.None);
+                });
+
+            Assert.NotNull(actual);
+            Assert.Equal(HttpStatusCode.NotFound, actual.Response.StatusCode);
+        }
+
+
         [DebugOnlyFact]
         public async Task get_last_5_modified_files()
         {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- This adds a integration test to validate the behavior when trying to call a GetByKeyAsync(...) and the requested entity does not exist.  It shows it throws an HttpOperationException with Response.StatusCode == HttpStatusCode.NotFound
- Adds a function to test if a file exists or not.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Added unit test to validate assertions

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
