### PR TITLE
Add exception destructuring, add config for serilog config

### DIFF
--- a/src/backend/Csrs.Api/Configuration/SerilogExtensions.cs
+++ b/src/backend/Csrs.Api/Configuration/SerilogExtensions.cs
@@ -1,6 +1,10 @@
 ﻿using Csrs.Api.Configuration;
+using Csrs.Api.Infrastructure;
 using Serilog;
 using Serilog.Events;
+using Serilog.Exceptions;
+using Serilog.Exceptions.Core;
+using Serilog.Exceptions.Destructurers;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -12,7 +16,11 @@ public static class SerilogExtensions
 
         builder.Host.UseSerilog((hostingContext, loggerConfiguration) =>
         {
-            loggerConfiguration.ReadFrom.Configuration(builder.Configuration);
+            loggerConfiguration
+                .ReadFrom.Configuration(builder.Configuration)
+                .Enrich.WithExceptionDetails(new DestructuringOptionsBuilder()
+                    .WithDefaultDestructurers()
+                    .WithDestructurers(new IExceptionDestructurer[] { new HttpOperationExceptionDestructurer(), new ValidationExceptionDestructurer() }));
 
 #if false
             loggerConfiguration.Enrich.With<GitVersionEnricher>();

--- a/src/backend/Csrs.Api/Csrs.Api.csproj
+++ b/src/backend/Csrs.Api/Csrs.Api.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+    <PackageReference Include="Serilog.Exceptions" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="5.1.1" />

--- a/src/backend/Csrs.Api/Infrastructure/HttpOperationExceptionDestructurer.cs
+++ b/src/backend/Csrs.Api/Infrastructure/HttpOperationExceptionDestructurer.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Rest;
+using Serilog.Exceptions.Core;
+using Serilog.Exceptions.Destructurers;
+
+namespace Csrs.Api.Infrastructure
+{
+    /// <summary>
+    /// Destructures <see cref="HttpOperationException"/> response properties.
+    /// </summary>
+    public class HttpOperationExceptionDestructurer : ExceptionDestructurer
+    {
+        public override Type[] TargetTypes => new[] { typeof(HttpOperationException) };
+
+        public override void Destructure(
+            Exception exception,
+            IExceptionPropertiesBag propertiesBag,
+            Func<Exception, IReadOnlyDictionary<string, object?>?> destructureException)
+        {
+            base.Destructure(exception, propertiesBag, destructureException);
+
+#pragma warning disable CA1062 // Validate arguments of public methods
+            var targetException = exception as HttpOperationException;
+            if (targetException is not null)
+            {
+                propertiesBag.AddProperty(nameof(HttpOperationException.Response.StatusCode), targetException.Response.StatusCode);
+                propertiesBag.AddProperty(nameof(HttpOperationException.Response.ReasonPhrase), targetException.Response.ReasonPhrase);
+                propertiesBag.AddProperty(nameof(HttpOperationException.Response.Content), targetException.Response.Content);
+            }
+#pragma warning restore CA1062 // Validate arguments of public methods
+        }
+    }
+}

--- a/src/backend/Csrs.Api/Infrastructure/LoggerExtensions.cs
+++ b/src/backend/Csrs.Api/Infrastructure/LoggerExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
 
-namespace Microsoft.Extensions.DependencyInjection;
+namespace Microsoft.Extensions.Logging;
 
 public static class LoggerExtensions
 {

--- a/src/backend/Csrs.Api/Infrastructure/SerializationExceptionDestructurer.cs
+++ b/src/backend/Csrs.Api/Infrastructure/SerializationExceptionDestructurer.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Rest;
+using Serilog.Exceptions.Core;
+using Serilog.Exceptions.Destructurers;
+
+namespace Csrs.Api.Infrastructure
+{
+    /// <summary>
+    /// Destructures <see cref="ValidationException"/> response properties.
+    /// Warning this could write out PII from the response content.
+    /// </summary>
+    public class SerializationExceptionDestructurer : ExceptionDestructurer
+    {
+        public override Type[] TargetTypes => new[] { typeof(SerializationException) };
+
+        public override void Destructure(
+            Exception exception,
+            IExceptionPropertiesBag propertiesBag,
+            Func<Exception, IReadOnlyDictionary<string, object?>?> destructureException)
+        {
+            base.Destructure(exception, propertiesBag, destructureException);
+
+#pragma warning disable CA1062 // Validate arguments of public methods
+            var targetException = exception as SerializationException;
+            if (targetException is not null)
+            {
+                // warning: response could have PII
+                propertiesBag.AddProperty(nameof(SerializationException.Content), targetException.Content);
+            }
+#pragma warning restore CA1062 // Validate arguments of public methods
+        }
+    }
+}

--- a/src/backend/Csrs.Api/Infrastructure/ValidationExceptionDestructurer.cs
+++ b/src/backend/Csrs.Api/Infrastructure/ValidationExceptionDestructurer.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Rest;
+using Serilog.Exceptions.Core;
+using Serilog.Exceptions.Destructurers;
+
+namespace Csrs.Api.Infrastructure
+{
+    /// <summary>
+    /// Destructures <see cref="ValidationException"/> response properties.
+    /// </summary>
+    public class ValidationExceptionDestructurer : ExceptionDestructurer
+    {
+        public override Type[] TargetTypes => new[] { typeof(ValidationException) };
+
+        public override void Destructure(
+            Exception exception,
+            IExceptionPropertiesBag propertiesBag,
+            Func<Exception, IReadOnlyDictionary<string, object?>?> destructureException)
+        {
+            base.Destructure(exception, propertiesBag, destructureException);
+
+#pragma warning disable CA1062 // Validate arguments of public methods
+            var targetException = exception as ValidationException;
+            if (targetException is not null)
+            {
+                propertiesBag.AddProperty(nameof(ValidationException.Rule), targetException.Rule);
+                propertiesBag.AddProperty(nameof(ValidationException.Target), targetException.Target);
+            }
+#pragma warning restore CA1062 // Validate arguments of public methods
+        }
+    }
+}

--- a/src/backend/Csrs.Api/appsettings.json
+++ b/src/backend/Csrs.Api/appsettings.json
@@ -5,9 +5,20 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  
+
   "Serilog": {
-    "Enrich": [ "FromLogContext", "WithMachineName", "WithProcessId", "WithThreadId" ]
+    "Using": [
+      "Serilog.Enrichers.Context",
+      "Serilog.Enrichers.Environment",
+      "Serilog.Enrichers.Process",
+      "Serilog.Enrichers.Thread",
+      "Serilog.Exceptions"
+    ],
+    "Enrich": [
+      "FromLogContext",
+      "WithMachineName",
+      "WithProcessId", 
+      "WithThreadId" ]
   },
 
   "AllowedHosts": "*"

--- a/src/backend/Csrs.TntegrationTest/Csrs.TntegrationTest.csproj
+++ b/src/backend/Csrs.TntegrationTest/Csrs.TntegrationTest.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -7,6 +7,14 @@
     <IsPackable>false</IsPackable>
 
     <UserSecretsId>e80d2dda-72b2-44f3-8efd-fd2efef4397d</UserSecretsId>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;0168</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;0168</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adds configuration settings to configure default serilog settings
- Adds code to configure serilog to destructure HttpOperationException and  ValidationException exceptions that can be thrown by Dynamics rest client
- Add setting to ignore unused variables in the integration test library - typically `catch (Exception ex)`
- 
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
