### PR TITLE
Register and inject SharePointFileManager into file service

### DIFF
--- a/src/backend/Csrs.Services.FileManager/Startup.cs
+++ b/src/backend/Csrs.Services.FileManager/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using Csrs.Interfaces;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -30,6 +31,8 @@ namespace Csrs.Services.FileManager
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddScoped<SharePointFileManager>();
+
             services.AddGrpc(options =>
             {
                 options.EnableDetailedErrors = true;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adds call to registered scoped SharePointFileManager in DI
- Inject SharePointFileManager directly into FileManagerService

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
