### PR TITLE
CSRS388 Items 7 and 8 and fileupload datetimeformat

### DIFF
--- a/src/backend/Csrs.Api/Extensions/FileSystemItemExtensions.cs
+++ b/src/backend/Csrs.Api/Extensions/FileSystemItemExtensions.cs
@@ -42,7 +42,7 @@
             {
                 string tmp = name.Substring(0, idx);
                 string ext = System.IO.Path.GetExtension(name);
-                name = tmp + DateTime.Now.ToString("ddMMyyyyhhmmss")+ ext;
+                name = tmp + DateTime.Now.ToString("_yyyyMMddhhmmss")+ ext;
             }
             string result = documentType + NameDocumentTypeSeparator + name;
             return result;

--- a/src/frontend/csrs-portal/src/app/components/communication/communication.component.html
+++ b/src/frontend/csrs-portal/src/app/components/communication/communication.component.html
@@ -24,13 +24,13 @@
                       <mat-form-field>
                         <mat-label>Select File</mat-label>
                         <mat-select formControlName="inboxFile" (selectionChange)="onInboxFileNumberChange ($event)">
+                          <mat-option  value="all">
+                            All
+                          </mat-option>
                           <mat-option *ngFor="let file of files" [value]="file.fileId">
                             {{file.fileNumber}}
                           </mat-option>
                         </mat-select>
-                        <mat-error *ngIf="inboxFile.hasError('required')">
-                          File is required.
-                        </mat-error>
                       </mat-form-field>
                     </div>
                     <div class="col-md-10">
@@ -233,7 +233,8 @@
                             class="BC-Gov-PrimaryButton"
                             color="primary"
                             style="width: 250px; float:right;"
-                            (click)="onUpload()">
+                            (click)="onUpload()"
+                            [disabled]="uploadDisabled">
                       Upload Document
                     </button>
                   </div>

--- a/src/frontend/csrs-portal/src/app/components/communication/communication.component.ts
+++ b/src/frontend/csrs-portal/src/app/components/communication/communication.component.ts
@@ -70,6 +70,7 @@ export class CommunicationComponent implements OnInit {
   // isUploaing: boolean = true;
   _token = '';
   selectedUploadFile: any;
+  public uploadDisabled = false;
 
   data: any = null;
   _reponse: HttpResponse<null>;
@@ -129,7 +130,7 @@ export class CommunicationComponent implements OnInit {
     });
 
     this.inboxFormGroup = this._formBuilder.group({
-      inboxFile: [null, Validators.required]
+      inboxFile: [null, ]
     });
 
     
@@ -144,8 +145,7 @@ export class CommunicationComponent implements OnInit {
           (this.accountSummary.body.files != null && this.accountSummary.body.files.length > 0)) {
           this.files = this.accountSummary.body.files;
           if (this.files.length == 1) {
-            this.inboxFile.patchValue(this.files[0].fileId);
-            this.selectedInboxFile = this.files[0];
+            this.inboxFile.patchValue('all');
             this.uploadFile.patchValue(this.files[0].fileId);
             this.selectedUploadFile = this.files[0];
             this.contactFile.patchValue(this.files[0].fileId);
@@ -222,14 +222,15 @@ export class CommunicationComponent implements OnInit {
   }
   onInboxFileNumberChange(ob): void {
     let fileValue = ob.value;
-    for (var i = 0; i < this.files.length; i++) {
-      if (fileValue == this.files[i].fileId) {
-        this.selectedInboxFile = this.files[i];
-
-        //TODO
-        this.getRemoteData();
+    this.selectedInboxFile = null;
+    if (fileValue && fileValue != 'all') {
+      for (var i = 0; i < this.files.length; i++) {
+        if (fileValue == this.files[i].fileId) {
+          this.selectedInboxFile = this.files[i];
+        }
       }
     }
+    this.getRemoteData();
   }
   clearContactForm(): void {
     this.showValidationMessages = false;
@@ -474,6 +475,7 @@ openDialog(): void {
 
   submitUploadedAttachment() {
     const fileData = new FormData();
+    this.uploadDisabled = true;
     fileData.append('file', this.selectedFile, this.selectedFile.name);
         this.logger.info('File Data', fileData);
      this.documentService.apiDocumentUploadattachmentPost(
@@ -492,6 +494,7 @@ openDialog(): void {
             color: 'green'
           };
           this.openDialog();
+          this.uploadDisabled = false;
       },
       error: (e) => {
         if (e.error instanceof Error) {
@@ -504,6 +507,7 @@ openDialog(): void {
             color: 'red'
           };
           this.openDialog();
+          this.uploadDisabled = false;
 
         } else {
             // Backend returns unsuccessful response codes such as 404, 500 etc.
@@ -516,11 +520,12 @@ openDialog(): void {
             color: 'red'
           };
           this.openDialog();
+          this.uploadDisabled = false;
           }
       },
       complete: () => this.logger.info('apiFileUploadattachmentPost is completed')
       });
-
+    
   }
   selectTab(index) {
     this.selectedTab = 0;


### PR DESCRIPTION
The "Upload Document" button on the "Upload Document" tab should be disabled when clicked, and re-enabled when the success message or error message is dismissed.
The "File" dropdown list for the Inbox page should not default to a File # is the user only has one file (it should default to all), and should contain a list item allowing the user to explicitly select "All" files, as well as each of the File IDs for their Files.
Also updated upload to append datetime as _yyyyMMsshhmmss

