### PR TITLE
Update SharePoint library to .NET 6, force sdk version

### DIFF
--- a/src/backend/Csrs.Interfaces.SharePoint/SharePoint.csproj
+++ b/src/backend/Csrs.Interfaces.SharePoint/SharePoint.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Csrs.Interfaces</RootNamespace>
 	<DebugType>portable</DebugType>
   </PropertyGroup>

--- a/src/backend/global.json
+++ b/src/backend/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.201",
+    "rollForward": "latestMajor"
+  }
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- updates SharePoint lib to target .NET 6
- Adds global.json to ensure sdk 6.0.201 is used.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [x] Version change


