### PR TITLE
[CSRS-448] .NET Runtime Upgrade

### DIFF
--- a/src/backend/Csrs.Services.FileManager/Dockerfile.rhel8
+++ b/src/backend/Csrs.Services.FileManager/Dockerfile.rhel8
@@ -12,7 +12,8 @@ RUN dotnet build "Csrs.Services.FileManager.csproj" -c Release -o /app/build
 FROM build AS publish
 RUN dotnet publish "Csrs.Services.FileManager.csproj" -c Release -o /app/publish
 
-FROM registry.access.redhat.com/ubi8/dotnet-60-runtime AS final
+# For fixing some of the vulnerabilities for CSRS-448
+FROM registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0-17.20220907105939 AS final
 WORKDIR /opt/app-root/app
 EXPOSE 8080
 COPY --from=publish /app/publish .

--- a/src/backend/Dockerfile.rhel8
+++ b/src/backend/Dockerfile.rhel8
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM registry.access.redhat.com/ubi8/dotnet-60-runtime AS base
+FROM registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0-17.20220907105939 AS base
 WORKDIR /opt/app-root/app
 EXPOSE 8080
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [CSRS-448] .NET runtime upgrade for two of the backend components. This upgrade will automatically make the desired/prescribed version of some of libraries available.  

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
- [X] Security Related Patch 

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?
This is OpenShift side of change.
Would be tested after build and push to OpenShift.

## Does the change impact or break the Docker build?

- [ ] Yes
- [X] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
