### PR TITLE
FAMS3-4213 Postal Strike Banner

### DIFF
--- a/src/frontend/csrs-portal/src/app/components/landing/landing.component.html
+++ b/src/frontend/csrs-portal/src/app/components/landing/landing.component.html
@@ -28,6 +28,13 @@
 
   <div class="background_image">
     <div class="container">
+      <section style="padding-top: 10px;">
+        <div style="color: red; border: 4px solid red; padding: 5px; text-align: center; font-size:20px;">
+          As a result of the Canada Post service disruption, there may be delays in sending and receiving documents if you do not have a portal account. We recommend you set up a portal account now.
+          <br/><br/>
+          Contact CSRS at CSRS&#64;gov.bc.ca or by calling 604-660-2528 for more information.
+        </div>
+      </section>
       <section [ngStyle]="{ 'display': disabledLogin == true ? 'block' : 'none' }">
         <div style="color: red; border: 4px solid red; padding: 5px; text-align: center;">
           Website maintenance in progress. We apologize for any inconvenience.


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

A new banner to warn  users of the impacts of the postal Strike
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/de30e2f8-8681-43c2-9adb-e060504fca3d">

- {[FAMS3-4213](https://jag.gov.bc.ca/jira/browse/FAMS3-4213)}

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran locally to make sure the banner appeared as expected.
