### PR TITLE
[CSRS-561] outbox messages documents issues

### DIFF
--- a/src/backend/Csrs.Api/Features/UserRequests/Create.cs
+++ b/src/backend/Csrs.Api/Features/UserRequests/Create.cs
@@ -135,11 +135,11 @@ namespace Csrs.Api.Features.UserRequests
 
                 if (party.SsgCsrspartyid == originFile._ssgPayorValue)
                 {
-                    task.FamsSentby = (int)FamsSendBy.Payor;
+                    task.FamsSentby = (int)FamsSentBy.Payor;
                 }
                 else if (party.SsgCsrspartyid == originFile._ssgRecipientValue)
                 {
-                    task.FamsSentby = (int)FamsSendBy.Recipient;
+                    task.FamsSentby = (int)FamsSentBy.Recipient;
                 }
                 else
                 {

--- a/src/backend/Csrs.Api/Features/UserRequests/Create.cs
+++ b/src/backend/Csrs.Api/Features/UserRequests/Create.cs
@@ -47,7 +47,7 @@ namespace Csrs.Api.Features.UserRequests
                 IAccountService accountService,
                 IFileService fileService,
                 ILogger<Handler> logger,
-                ITaskService taskService )
+                ITaskService taskService)
             {
                 _dynamicsClient = dynamicsClient ?? throw new ArgumentNullException(nameof(dynamicsClient));
                 _userService = userService ?? throw new ArgumentNullException(nameof(userService));
@@ -76,7 +76,7 @@ namespace Csrs.Api.Features.UserRequests
                     _logger.LogInformation("No BCeID on authenticated user, cannot create User Request");
                     return new Response("Unauthenticated");
                 }
-                
+
                 _logger.AddBCeIdGuid(userId);
                 MicrosoftDynamicsCRMssgCsrspartyCollection parties = await _dynamicsClient.GetPartyByBCeIdAsync(userId, cancellationToken);
 
@@ -99,7 +99,7 @@ namespace Csrs.Api.Features.UserRequests
                     Prioritycode = 1,   // Normal
                     Statuscode = 2,     // Not Started
                     Scheduledend = DateTimeOffset.UtcNow
-                };             
+                };
                 //Get the file
                 _logger.AddFileId(request.FileId);
                 MicrosoftDynamicsCRMssgCsrsfile originFile;
@@ -133,6 +133,19 @@ namespace Csrs.Api.Features.UserRequests
 
                 task.RegardingobjectidSsgCsrsfileODataBind = _dynamicsClient.GetEntityURI("ssg_csrsfiles", originFile.SsgCsrsfileid);
 
+                if (party.SsgCsrspartyid == originFile._ssgPayorValue)
+                {
+                    task.FamsSentby = (int)FamsSendBy.Payor;
+                }
+                else if (party.SsgCsrspartyid == originFile._ssgRecipientValue)
+                {
+                    task.FamsSentby = (int)FamsSendBy.Recipient;
+                }
+                else
+                {
+                    _logger.LogWarning("Party {PartyId} is neither Payor nor Recipient on file {FileId}", party.SsgCsrspartyid, request.FileId);
+                }
+
                 //ap.Statecode = 0;  defaults in DB
                 MicrosoftDynamicsCRMtask result = await _dynamicsClient.Tasks.CreateAsync(task);
                 _logger.AddProperty("ActivityId", result.Activityid);
@@ -146,7 +159,7 @@ namespace Csrs.Api.Features.UserRequests
                         request.RequestType
                     );
                 }
-                
+
                 return new Response("User Request Created");
             }
         }

--- a/src/backend/Csrs.Api/Repositories/DynamicsExtensions.cs
+++ b/src/backend/Csrs.Api/Repositories/DynamicsExtensions.cs
@@ -154,7 +154,7 @@ namespace Csrs.Interfaces.Dynamics
             partyId = GuidGuard(partyId);
 
             string filter = $"_ssg_payor_value eq {partyId} or _ssg_recipient_value eq {partyId}";
-            List<string> select = new List<string> { "ssg_csrsfileid", "ssg_filenumber" };
+            List<string> select = new List<string> { "ssg_csrsfileid", "ssg_filenumber", "_ssg_payor_value", "_ssg_recipient_value" };
             List<string> orderby = new List<string> { "modifiedon desc" };
 
             var files = await dynamicsClient.Ssgcsrsfiles.GetAsync(select: select, orderby: orderby, filter: filter, expand: null, cancellationToken: cancellationToken);
@@ -180,7 +180,8 @@ namespace Csrs.Interfaces.Dynamics
             string partyId,
             bool isSent,
             CancellationToken cancellationToken,
-            ILogger logger)
+            ILogger logger,
+            int? sentByValue = null)
         {
             ArgumentNullException.ThrowIfNull(dynamicsClient);
 
@@ -213,6 +214,10 @@ namespace Csrs.Interfaces.Dynamics
             List<string> orderbyTask = new List<string> { "createdon desc" };
             List<string> expandTask = new List<string> { "createdby", "modifiedby", "ownerid", "owninguser", "regardingobjectid_ssg_csrsfile_task" };
             string filterTasks = $"_regardingobjectid_value eq {fileId} and fams_origin eq 451190000";
+            if (sentByValue.HasValue)
+            {
+                filterTasks += $" and fams_sentby eq {sentByValue.Value}";
+            }
 
             var tasks = await dynamicsClient.Tasks.GetAsync(
                 orderby: orderbyTask,

--- a/src/backend/Csrs.Api/Repositories/DynamicsExtensions.cs
+++ b/src/backend/Csrs.Api/Repositories/DynamicsExtensions.cs
@@ -52,7 +52,7 @@ namespace Csrs.Interfaces.Dynamics
 
         public static async Task<MicrosoftDynamicsCRMssgCsrsfile> GetFileByPartyAndId(this IDynamicsClient dynamicsClient, string partyId, string fileId, CancellationToken cancellationToken)
         {
-            
+
             ArgumentNullException.ThrowIfNull(dynamicsClient);
 
             if (string.IsNullOrEmpty(partyId) || string.IsNullOrEmpty(fileId))
@@ -62,7 +62,7 @@ namespace Csrs.Interfaces.Dynamics
 
             try
             {
-                
+
                 var filter = $"(_ssg_recipient_value eq {partyId} or _ssg_payor_value eq {partyId}) and ssg_csrsfileid eq {fileId}";
                 var select = new List<string> { "ssg_csrsfileid", "ssg_filenumber" };
 
@@ -87,7 +87,7 @@ namespace Csrs.Interfaces.Dynamics
 
             List<string> select = new List<string> { "ssg_csrspartyid" };
             List<string> orderby = new List<string> { "ssg_bceid_last_update desc" };
-            string filter = $"ssg_bceid_guid eq '{bceid}' and {ActiveStateCode}"; 
+            string filter = $"ssg_bceid_guid eq '{bceid}' and {ActiveStateCode}";
             try
             {
                 var parties = await dynamicsClient.Ssgcsrsparties.GetAsync(filter: filter, orderby: orderby, cancellationToken: cancellationToken);
@@ -169,16 +169,16 @@ namespace Csrs.Interfaces.Dynamics
             fileId = GuidGuard(fileId);
 
             string filter = $"ssg_csrsfileid eq {fileId}";
-            List<string> select = new List<string> { "ssg_csrsfileid", "ssg_filenumber", "_ownerid_value", "_owninguser_value", "_owningteam_value" };
-           
+            List<string> select = new List<string> { "ssg_csrsfileid", "ssg_filenumber", "_ownerid_value", "_owninguser_value", "_owningteam_value", "_ssg_payor_value", "_ssg_recipient_value" };
+
             return await dynamicsClient.Ssgcsrsfiles.GetByKeyAsync(fileId, select: select, expand: null, cancellationToken: cancellationToken);
         }
 
         public static async Task<MicrosoftDynamicsCRMssgCsrscommunicationmessageCollection> GetCommunicationMessagesByFile(
-            this IDynamicsClient dynamicsClient, 
-            string fileId, 
-            string partyId, 
-            bool isSent, 
+            this IDynamicsClient dynamicsClient,
+            string fileId,
+            string partyId,
+            bool isSent,
             CancellationToken cancellationToken,
             ILogger logger)
         {
@@ -280,7 +280,7 @@ namespace Csrs.Interfaces.Dynamics
             referenceNumber = Escape(referenceNumber);
 
             string filter = $"ssg_referencenumber eq '{referenceNumber}'";
-            var  parties = await dynamicsClient.Ssgcsrsparties.GetAsync(filter: filter, cancellationToken: cancellationToken);
+            var parties = await dynamicsClient.Ssgcsrsparties.GetAsync(filter: filter, cancellationToken: cancellationToken);
             return parties;
         }
 
@@ -344,10 +344,10 @@ namespace Csrs.Interfaces.Dynamics
 
             return role;
         }
-        
 
 
-public static async Task<MicrosoftDynamicsCRMssgCsrscommunicationmessage> GetCommunicationMessagesByPartyAndIdAsync(this IDynamicsClient dynamicsClient, string partyId, string messageId, CancellationToken cancellationToken)
+
+        public static async Task<MicrosoftDynamicsCRMssgCsrscommunicationmessage> GetCommunicationMessagesByPartyAndIdAsync(this IDynamicsClient dynamicsClient, string partyId, string messageId, CancellationToken cancellationToken)
         {
 
             ArgumentNullException.ThrowIfNull(dynamicsClient);
@@ -356,7 +356,7 @@ public static async Task<MicrosoftDynamicsCRMssgCsrscommunicationmessage> GetCom
             messageId = GuidGuard(messageId);
 
             var filter = $"(_ssg_toparty_value eq {partyId} or _ssg_fromparty_value eq {partyId}) and ssg_csrscommunicationmessageid eq {messageId}";
-            var select = new List<string> { "ssg_csrscommunicationmessageid" , "ssg_csrsmessagesubject" };
+            var select = new List<string> { "ssg_csrscommunicationmessageid", "ssg_csrsmessagesubject" };
 
             var messages = await dynamicsClient.Ssgcsrscommunicationmessages.GetAsync(filter: filter, select: select, cancellationToken: cancellationToken);
 
@@ -460,7 +460,7 @@ public static async Task<MicrosoftDynamicsCRMssgCsrscommunicationmessage> GetCom
         {
 
             relativeUrl = Escape(relativeUrl);
-            
+
             var filter = $"relativeurl eq '{relativeUrl}'";
             var select = new List<string> { "sharepointdocumentlocationid" };
 

--- a/src/backend/Csrs.Api/Services/MessageService.cs
+++ b/src/backend/Csrs.Api/Services/MessageService.cs
@@ -54,7 +54,16 @@ namespace Csrs.Api.Services
 
                     _logger.LogDebug("IsSent={IsSent}, Processing FileId={FileId}", isSent, file.SsgCsrsfileid);
 
-                    MicrosoftDynamicsCRMssgCsrscommunicationmessageCollection dynamicsMessages = await _dynamicsClient.GetCommunicationMessagesByFile(file.SsgCsrsfileid, partyId, isSent, cancellationToken, _logger);
+                    int? sentByValue = null;
+                    if (isSent)
+                    {
+                        if (file._ssgPayorValue == partyId)
+                            sentByValue = (int)FamsSentBy.Payor;
+                        else if (file._ssgRecipientValue == partyId)
+                            sentByValue = (int)FamsSentBy.Recipient;
+                    }
+
+                    MicrosoftDynamicsCRMssgCsrscommunicationmessageCollection dynamicsMessages = await _dynamicsClient.GetCommunicationMessagesByFile(file.SsgCsrsfileid, partyId, isSent, cancellationToken, _logger, sentByValue);
 
                     if (dynamicsMessages == null || dynamicsMessages.Value == null)
                     {
@@ -148,7 +157,7 @@ namespace Csrs.Api.Services
                         {
                             _logger.LogError(
                                 ex,
-                                "IsSent={IsSent}, ERROR OCCURRED getting attachment list for MessageId={MessageId}, Subject={Subject}: {Message}", 
+                                "IsSent={IsSent}, ERROR OCCURRED getting attachment list for MessageId={MessageId}, Subject={Subject}: {Message}",
                                 isSent,
                                 message.SsgCsrscommunicationmessageid,
                                 message.SsgCsrsmessagesubject,
@@ -178,15 +187,17 @@ namespace Csrs.Api.Services
         {
             _logger.LogDebug("Set party message read request recieved");
 
-            var select = new List<string>() {"ssg_csrsmessageread"};
+            var select = new List<string>() { "ssg_csrsmessageread" };
 
             var communicationMessage = await _dynamicsClient.Ssgcsrscommunicationmessages.GetByKeyAsync(messageGuid, select, null, cancellationToken);
-            if (communicationMessage is null) {
+            if (communicationMessage is null)
+            {
                 _logger.LogInformation("No associated message Guid, cannot set message to read");
                 throw new HttpOperationException("Incorrect message Guid");
             }
 
-            if (communicationMessage.SsgCsrsmessageread == false) {
+            if (communicationMessage.SsgCsrsmessageread == false)
+            {
                 communicationMessage.SsgCsrsmessageread = true;
 
                 await _dynamicsClient.Ssgcsrscommunicationmessages.UpdateAsync(messageGuid, communicationMessage, cancellationToken);

--- a/src/backend/Csrs.Interfaces.Dynamics/ModelExtensions/FamsSendBy.cs
+++ b/src/backend/Csrs.Interfaces.Dynamics/ModelExtensions/FamsSendBy.cs
@@ -1,0 +1,11 @@
+namespace Csrs.Interfaces.Dynamics.Models
+{
+    /// <summary>
+    /// Picklist values for task.fams_sendby
+    /// </summary>
+    public enum FamsSendBy
+    {
+        Payor = 451190000,
+        Recipient = 451190001
+    }
+}

--- a/src/backend/Csrs.Interfaces.Dynamics/ModelExtensions/FamsSentBy.cs
+++ b/src/backend/Csrs.Interfaces.Dynamics/ModelExtensions/FamsSentBy.cs
@@ -1,9 +1,9 @@
 namespace Csrs.Interfaces.Dynamics.Models
 {
     /// <summary>
-    /// Picklist values for task.fams_sendby
+    /// Picklist values for task.fams_sentby
     /// </summary>
-    public enum FamsSendBy
+    public enum FamsSentBy
     {
         Payor = 451190000,
         Recipient = 451190001

--- a/src/backend/Csrs.Interfaces.Dynamics/ModelExtensions/MicrosoftDynamicsCRMtask.cs
+++ b/src/backend/Csrs.Interfaces.Dynamics/ModelExtensions/MicrosoftDynamicsCRMtask.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Csrs.Interfaces.Dynamics.Models
 {
-    
+
     class MicrosoftDynamicsCRMtaskMetadata
     {
     }
@@ -19,5 +19,8 @@ namespace Csrs.Interfaces.Dynamics.Models
 
         [JsonProperty(PropertyName = "fams_origin")]
         public int? FamsOrigin { get; set; }
+
+        [JsonProperty(PropertyName = "fams_sentby")]
+        public int? FamsSentby { get; set; }
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

This pull request introduces enhancements to the handling of party roles (Payor/Recipient) and message retrieval in the CSRS API. The main improvements are around tracking which party sent a message or task, and ensuring this information is accurately passed through the service and repository layers. Additionally, the changes add robustness to message read operations and expand select fields for file queries.

**Enhancements to party role tracking and message retrieval:**

* Added a new `FamsSentBy` enum to represent Payor and Recipient roles, and integrated it into task creation logic to record which party sent a task (`fams_sentby`). [[1]](diffhunk://#diff-35ba173e35dc1af6f9426b4686997dd4d79b8d952dfc0c4133073d021f3125faR1-R11) [[2]](diffhunk://#diff-cbd91f4a2ec96af645755fd555c055fa7e283ce77710d57adb7cb46b8667cba7R22-R24) [[3]](diffhunk://#diff-12b36ec3d18cd5d9ec2bdc41177572a432f055ef384cb24c47891df6cc8a1955R136-R148)
* Updated message retrieval logic in `MessageService` to determine and pass the correct `sentByValue` based on party role, enabling more accurate filtering of messages by sender.
* Modified `GetCommunicationMessagesByFile` in `DynamicsExtensions` to accept an optional `sentByValue` parameter and use it for filtering tasks/messages. [[1]](diffhunk://#diff-3685517a78766bd62b63cb84a73e0bc500fecfa66697d5714e1753f4ed405804L183-R184) [[2]](diffhunk://#diff-3685517a78766bd62b63cb84a73e0bc500fecfa66697d5714e1753f4ed405804R217-R220)

**Improvements to file queries:**

* Expanded the select fields for file queries to include `_ssg_payor_value` and `_ssg_recipient_value`, ensuring party role information is available when retrieving files. [[1]](diffhunk://#diff-3685517a78766bd62b63cb84a73e0bc500fecfa66697d5714e1753f4ed405804L157-R157) [[2]](diffhunk://#diff-3685517a78766bd62b63cb84a73e0bc500fecfa66697d5714e1753f4ed405804L172-R172)

**Robustness improvements:**

* Improved null checks and logging in the `SetMessageRead` method to handle missing message GUIDs and ensure messages are only marked as read when appropriate.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
