### PR TITLE
[CSRS-645] SharePoint online integration

### DIFF
--- a/openshift/jag-csrs-file-manager.yml
+++ b/openshift/jag-csrs-file-manager.yml
@@ -81,6 +81,26 @@ parameters:
   description: sharepoint location
   required: true
   value: sharepoint_blah_blah_location
+
+- name: USE_SHAREPOINT_ONLINE_CONTINGENCY
+  description: When set to 'true', routes document storage to SharePoint Online (OAuth2) instead of on-premises SharePoint (SAML). Set to 'false' or omit to use on-premises behaviour.
+  required: false
+  value: "false"
+
+- name: SPO_TENANT_ID
+  description: Azure AD / Entra ID tenant ID for SharePoint Online authentication (required when UseSharePointOnlineContingency=true)
+  required: false
+  value: ""
+
+- name: SPO_CLIENT_ID
+  description: Application (client) ID registered in Azure AD for SharePoint Online (required when UseSharePointOnlineContingency=true)
+  required: false
+  value: ""
+
+- name: SPO_RESOURCE
+  description: SharePoint Online site root URL, e.g. https://tenant.sharepoint.com/sites/csrs/ (required when UseSharePointOnlineContingency=true)
+  required: false
+  value: ""
 - name: CA_MOUNT_PATH
   description: ca mount path
   required: true
@@ -207,6 +227,32 @@ objects:
                 secretKeyRef:
                   name:  ${FILEMANAGER_CONFIG_NAME}
                   key: RESOURCE
+            - name: UseSharePointOnlineContingency
+              value: ${USE_SHAREPOINT_ONLINE_CONTINGENCY}
+            - name: SPO_TENANT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: ${FILEMANAGER_CONFIG_NAME}
+                  key: SPO_TENANT_ID
+                  optional: true
+            - name: SPO_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: ${FILEMANAGER_CONFIG_NAME}
+                  key: SPO_CLIENT_ID
+                  optional: true
+            - name: SPO_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: ${FILEMANAGER_CONFIG_NAME}
+                  key: SPO_CLIENT_SECRET
+                  optional: true
+            - name: SPO_RESOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: ${FILEMANAGER_CONFIG_NAME}
+                  key: SPO_RESOURCE
+                  optional: true
             - name: OPENSHIFT
               value: ${OPENSHIFT}
             - name: SSL_CERT_DIR

--- a/src/backend/Csrs.Api/WebApplicationBuilderExtensions.cs
+++ b/src/backend/Csrs.Api/WebApplicationBuilderExtensions.cs
@@ -96,7 +96,7 @@ public static class WebApplicationBuilderExtensions
     private static void ConfigureFileManagerService(WebApplicationBuilder builder, FileManagerConfiguration? configuration)
     {
         var logger = Log.ForContext(typeof(WebApplicationBuilderExtensions));
-        
+
         if (string.IsNullOrWhiteSpace(configuration?.Address))
         {
             const string message = $"FileManager configuration is not set, {nameof(CsrsConfiguration.FileManager)}:{nameof(FileManagerConfiguration.Address)} is required.";
@@ -112,6 +112,8 @@ public static class WebApplicationBuilderExtensions
         if (configuration.Secure.HasValue && !configuration.Secure.Value)
         {
             logger.Information("Configuration explicitly set Secure=false. Using insecure channel for File Manager service.");
+            // Required for Grpc.Net.Client to use h2c (unencrypted HTTP/2) on .NET 6
+            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
             credentials = ChannelCredentials.Insecure;
         }
         else

--- a/src/backend/Csrs.Interfaces.SharePoint/Extensions.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/Extensions.cs
@@ -9,13 +9,13 @@ namespace Csrs.Interfaces
         /// <summary>
         /// Adds the required services to use SharePoint file management.
         /// When <c>UseSharePointOnlineContingency</c> is set to <c>true</c> in configuration,
-        /// registers <see cref="SharePointOnlineFileManager"/> (OAuth2 bearer token, SharePoint Online).
+        /// registers <see cref="SharePointOnlineFileManager"/> (Microsoft Graph API, SharePoint Online).
         /// Otherwise registers <see cref="SharePointFileManager"/> (SAML / FedAuth, on-premises).
         /// </summary>
         public static void AddSharePointIntegration(this IServiceCollection services, IConfiguration configuration)
         {
             bool useSpo = string.Equals(
-                configuration["USE_SHAREPOINT_ONLINE_CONTINGENCY"],
+                configuration["USE_SHAREPOINT_ONLINE_CONTINGENCY"] ?? configuration["UseSharePointOnlineContingency"],
                 "true",
                 StringComparison.OrdinalIgnoreCase);
 

--- a/src/backend/Csrs.Interfaces.SharePoint/Extensions.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/Extensions.cs
@@ -7,19 +7,34 @@ namespace Csrs.Interfaces
     public static class Extensions
     {
         /// <summary>
-        /// Adds the requires services to be able to use SharePointFileManager.
+        /// Adds the required services to use SharePoint file management.
+        /// When <c>UseSharePointOnlineContingency</c> is set to <c>true</c> in configuration,
+        /// registers <see cref="SharePointOnlineFileManager"/> (OAuth2 bearer token, SharePoint Online).
+        /// Otherwise registers <see cref="SharePointFileManager"/> (SAML / FedAuth, on-premises).
         /// </summary>
-        /// <param name="services"></param>
-        public static void AddSharePointIntegration(this IServiceCollection services)
+        public static void AddSharePointIntegration(this IServiceCollection services, IConfiguration configuration)
         {
-            services.AddSingleton(GetSharePointFileManagerConfiguration);
-            services.AddScoped<SharePointFileManager>();
+            bool useSpo = string.Equals(
+                configuration["USE_SHAREPOINT_ONLINE_CONTINGENCY"],
+                "true",
+                StringComparison.OrdinalIgnoreCase);
 
-            // SAML services
-            // token caches are singleton because they maintain a per instance prefix
-            // that can be changed to effectively clear the cache
-            services.AddSingleton<ITokenCache<SamlTokenParameters, string>, SamlTokenTokenCache>();
-            services.AddTransient<ISamlAuthenticator, SamlAuthenticator>();
+            if (useSpo)
+            {
+                services.AddSingleton(GetSharePointOnlineConfiguration);
+                services.AddSingleton<ISharePointOnlineAuthenticator, SharePointOnlineAuthenticator>();
+                services.AddScoped<ISharePointFileManager, SharePointOnlineFileManager>();
+            }
+            else
+            {
+                services.AddSingleton(GetSharePointFileManagerConfiguration);
+                // SAML services
+                // token caches are singleton because they maintain a per instance prefix
+                // that can be changed to effectively clear the cache
+                services.AddSingleton<ITokenCache<SamlTokenParameters, string>, SamlTokenTokenCache>();
+                services.AddTransient<ISamlAuthenticator, SamlAuthenticator>();
+                services.AddScoped<ISharePointFileManager, SharePointFileManager>();
+            }
 
             services.AddMemoryCache();
         }
@@ -41,5 +56,19 @@ namespace Csrs.Interfaces
 
             return sharePointFileManagerConfiguration;
         }
+
+        private static SharePointOnlineConfiguration GetSharePointOnlineConfiguration(IServiceProvider serviceProvider)
+        {
+            IConfiguration configuration = serviceProvider.GetService<IConfiguration>();
+
+            return new SharePointOnlineConfiguration
+            {
+                TenantId = configuration["SPO_TENANT_ID"],
+                ClientId = configuration["SPO_CLIENT_ID"],
+                ClientSecret = configuration["SPO_CLIENT_SECRET"],
+                Resource = new Uri(configuration["SPO_RESOURCE"]),
+            };
+        }
     }
 }
+

--- a/src/backend/Csrs.Interfaces.SharePoint/Extensions.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/Extensions.cs
@@ -66,8 +66,19 @@ namespace Csrs.Interfaces
                 TenantId = configuration["SPO_TENANT_ID"],
                 ClientId = configuration["SPO_CLIENT_ID"],
                 ClientSecret = configuration["SPO_CLIENT_SECRET"],
-                Resource = new Uri(configuration["SPO_RESOURCE"]),
+                Resource = CreateResourceUri(configuration["SPO_RESOURCE"] ?? configuration["RESOURCE"]),
             };
+        }
+
+        private static Uri CreateResourceUri(string resource)
+        {
+            if (string.IsNullOrWhiteSpace(resource))
+            {
+                throw new InvalidOperationException(
+                    "SPO_RESOURCE must be set to the SharePoint site URL, e.g. https://tenant.sharepoint.com/sites/jsb-fams-dev/");
+            }
+
+            return new Uri(resource.TrimEnd('/') + "/");
         }
     }
 }

--- a/src/backend/Csrs.Interfaces.SharePoint/ISharePointFileManager.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/ISharePointFileManager.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Csrs.Interfaces
+{
+    public interface ISharePointFileManager
+    {
+        Task<List<FileDetailsList>> GetFileDetailsListInFolder(string listTitle, string folderName, string documentType);
+
+        Task CreateFolder(string listTitle, string folderName);
+
+        Task<object> CreateDocumentLibrary(string listTitle, string documentTemplateUrlTitle = null);
+
+        Task<object> UpdateDocumentLibrary(string listTitle);
+
+        Task<bool> DeleteFolder(string listTitle, string folderName);
+
+        Task<bool> FolderExists(string listTitle, string folderName);
+
+        Task<bool> DocumentLibraryExists(string listTitle);
+
+        Task<object> GetFolder(string listTitle, string folderName);
+
+        Task<object> GetDocumentLibrary(string listTitle);
+
+        Task<string> AddFile(string folderName, string fileName, Stream fileData, string contentType);
+
+        Task<string> AddFile(string documentLibrary, string folderName, string fileName, Stream fileData, string contentType);
+
+        Task<string> AddFile(string folderName, string fileName, byte[] fileData, string contentType);
+
+        Task<string> AddFile(string documentLibrary, string folderName, string fileName, byte[] fileData, string contentType);
+
+        Task<string> UploadFile(string fileName, string listTitle, string folderName, Stream fileData, string contentType);
+
+        string GetTruncatedFileName(string fileName, string listTitle, string folderName);
+
+        Task<string> UploadFile(string fileName, string listTitle, string folderName, byte[] data, string contentType);
+
+        Task<string> UpdateListItemFields(AddFileResponse itemData, string listTitle, string contentType, string fileName);
+
+        Task<byte[]> DownloadFile(string url);
+
+        Task<bool> DeleteFile(string listTitle, string folderName, string fileName);
+
+        Task<bool> DeleteFile(string serverRelativeUrl);
+
+        Task<bool> RenameFile(string oldServerRelativeUrl, string newServerRelativeUrl);
+    }
+}

--- a/src/backend/Csrs.Interfaces.SharePoint/ISharePointOnlineAuthenticator.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/ISharePointOnlineAuthenticator.cs
@@ -5,7 +5,7 @@ namespace Csrs.Interfaces
     public interface ISharePointOnlineAuthenticator
     {
         /// <summary>
-        /// Returns a valid OAuth2 bearer token for SharePoint Online.
+        /// Returns a valid OAuth2 bearer token for Microsoft Graph.
         /// Tokens are cached internally until they expire.
         /// </summary>
         Task<string> GetAccessTokenAsync();

--- a/src/backend/Csrs.Interfaces.SharePoint/ISharePointOnlineAuthenticator.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/ISharePointOnlineAuthenticator.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace Csrs.Interfaces
+{
+    public interface ISharePointOnlineAuthenticator
+    {
+        /// <summary>
+        /// Returns a valid OAuth2 bearer token for SharePoint Online.
+        /// Tokens are cached internally until they expire.
+        /// </summary>
+        Task<string> GetAccessTokenAsync();
+    }
+}

--- a/src/backend/Csrs.Interfaces.SharePoint/SharePointFileManager.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/SharePointFileManager.cs
@@ -20,7 +20,7 @@ using System.Xml;
 namespace Csrs.Interfaces
 {
 
-    public class SharePointFileManager
+    public class SharePointFileManager : ISharePointFileManager
     {
         public const string DefaultDocumentUrlTitle = "account";
         public const string ApplicationDocumentListTitle = "Application";
@@ -104,7 +104,7 @@ namespace Csrs.Interfaces
             {
                 response = await httpClient.SendAsync(request);
             }
-            catch(ArgumentNullException e)
+            catch (ArgumentNullException e)
             {
                 var ex = new SharePointRestException("The response is null.");
                 ex.Request = new HttpRequestMessageWrapper(request, null);
@@ -112,7 +112,7 @@ namespace Csrs.Interfaces
                 _logger.LogError("The response is null.");
                 throw ex;
             }
-            catch(InvalidOperationException e)
+            catch (InvalidOperationException e)
             {
                 var ex = new SharePointRestException("The request message was already sent by the HttpClient instance.");
                 ex.Request = new HttpRequestMessageWrapper(request, null);

--- a/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineAuthenticator.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineAuthenticator.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Csrs.Interfaces
+{
+    internal class SharePointOnlineAuthenticator : ISharePointOnlineAuthenticator
+    {
+        private const string CacheKey = "SharePointOnlineAccessToken";
+        // Subtract 60 seconds from the token lifetime as a buffer to avoid using an expiring token
+        private const int ExpiryBufferSeconds = 60;
+
+        private readonly SharePointOnlineConfiguration _configuration;
+        private readonly IMemoryCache _cache;
+        private readonly ILogger<SharePointOnlineAuthenticator> _logger;
+
+        public SharePointOnlineAuthenticator(
+            SharePointOnlineConfiguration configuration,
+            IMemoryCache cache,
+            ILogger<SharePointOnlineAuthenticator> logger)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<string> GetAccessTokenAsync()
+        {
+            if (_cache.TryGetValue(CacheKey, out string cachedToken))
+            {
+                _logger.LogTrace("Returning cached SharePoint Online access token");
+                return cachedToken;
+            }
+
+            _logger.LogDebug("Requesting new SharePoint Online access token for tenant {TenantId}", _configuration.TenantId);
+
+            string tokenUrl = $"https://login.microsoftonline.com/{_configuration.TenantId}/oauth2/v2.0/token";
+            string scope = $"https://{_configuration.Resource.Host}/.default";
+
+            using var client = new HttpClient();
+
+            var requestBody = new Dictionary<string, string>
+            {
+                ["grant_type"] = "client_credentials",
+                ["client_id"] = _configuration.ClientId,
+                ["client_secret"] = _configuration.ClientSecret,
+                ["scope"] = scope,
+            };
+
+            using var content = new FormUrlEncodedContent(requestBody);
+            var response = await client.PostAsync(tokenUrl, content);
+
+            string responseJson = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("Failed to acquire SharePoint Online access token. StatusCode={StatusCode}", response.StatusCode);
+                throw new SamlAuthenticationException($"SharePoint Online token request failed with status {response.StatusCode}");
+            }
+
+            var tokenResponse = JsonConvert.DeserializeObject<OAuthTokenResponse>(responseJson);
+            if (tokenResponse?.AccessToken == null)
+            {
+                _logger.LogError("SharePoint Online token response did not contain an access token");
+                throw new SamlAuthenticationException("SharePoint Online token response did not contain an access token");
+            }
+
+            int expiresIn = tokenResponse.ExpiresIn > ExpiryBufferSeconds
+                ? tokenResponse.ExpiresIn - ExpiryBufferSeconds
+                : tokenResponse.ExpiresIn;
+
+            var expiry = DateTimeOffset.UtcNow.AddSeconds(expiresIn);
+            _cache.Set(CacheKey, tokenResponse.AccessToken, expiry);
+
+            _logger.LogInformation("SharePoint Online access token acquired and cached until {Expiry}", expiry);
+
+            return tokenResponse.AccessToken;
+        }
+    }
+
+    internal class OAuthTokenResponse
+    {
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+
+        [JsonProperty("expires_in")]
+        public int ExpiresIn { get; set; }
+
+        [JsonProperty("token_type")]
+        public string TokenType { get; set; }
+    }
+}

--- a/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineAuthenticator.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineAuthenticator.cs
@@ -36,10 +36,10 @@ namespace Csrs.Interfaces
                 return cachedToken;
             }
 
-            _logger.LogDebug("Requesting new SharePoint Online access token for tenant {TenantId}", _configuration.TenantId);
+            _logger.LogDebug("Requesting new Microsoft Graph access token for tenant {TenantId}", _configuration.TenantId);
 
             string tokenUrl = $"https://login.microsoftonline.com/{_configuration.TenantId}/oauth2/v2.0/token";
-            string scope = $"https://{_configuration.Resource.Host}/.default";
+            const string scope = "https://graph.microsoft.com/.default";
 
             using var client = new HttpClient();
 
@@ -58,15 +58,15 @@ namespace Csrs.Interfaces
 
             if (!response.IsSuccessStatusCode)
             {
-                _logger.LogError("Failed to acquire SharePoint Online access token. StatusCode={StatusCode}", response.StatusCode);
-                throw new SamlAuthenticationException($"SharePoint Online token request failed with status {response.StatusCode}");
+                _logger.LogError("Failed to acquire Microsoft Graph access token. StatusCode={StatusCode}", response.StatusCode);
+                throw new SamlAuthenticationException($"Microsoft Graph token request failed with status {response.StatusCode}");
             }
 
             var tokenResponse = JsonConvert.DeserializeObject<OAuthTokenResponse>(responseJson);
             if (tokenResponse?.AccessToken == null)
             {
-                _logger.LogError("SharePoint Online token response did not contain an access token");
-                throw new SamlAuthenticationException("SharePoint Online token response did not contain an access token");
+                _logger.LogError("Microsoft Graph token response did not contain an access token");
+                throw new SamlAuthenticationException("Microsoft Graph token response did not contain an access token");
             }
 
             int expiresIn = tokenResponse.ExpiresIn > ExpiryBufferSeconds
@@ -76,7 +76,7 @@ namespace Csrs.Interfaces
             var expiry = DateTimeOffset.UtcNow.AddSeconds(expiresIn);
             _cache.Set(CacheKey, tokenResponse.AccessToken, expiry);
 
-            _logger.LogInformation("SharePoint Online access token acquired and cached until {Expiry}", expiry);
+            _logger.LogInformation("Microsoft Graph access token acquired and cached until {Expiry}", expiry);
 
             return tokenResponse.AccessToken;
         }

--- a/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineConfiguration.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineConfiguration.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Csrs.Interfaces
+{
+    public class SharePointOnlineConfiguration
+    {
+        /// <summary>
+        /// The Azure AD / Entra ID tenant identifier.
+        /// </summary>
+        public string TenantId { get; set; }
+
+        /// <summary>
+        /// The application (client) identifier registered in Azure AD.
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// The client secret for the registered application.
+        /// </summary>
+        public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// The SharePoint Online site URL used as the resource base address.
+        /// </summary>
+        public Uri Resource { get; set; }
+    }
+}

--- a/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineConfiguration.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineConfiguration.cs
@@ -20,8 +20,14 @@ namespace Csrs.Interfaces
         public string ClientSecret { get; set; }
 
         /// <summary>
-        /// The SharePoint Online site URL used as the resource base address.
+        /// The SharePoint Online site URL (e.g. https://tenant.sharepoint.com/sites/csrs/).
+        /// Used to resolve the site in Microsoft Graph and to build server-relative URLs.
         /// </summary>
         public Uri Resource { get; set; }
+
+        /// <summary>
+        /// Microsoft Graph API base URL.
+        /// </summary>
+        public Uri GraphBaseUri { get; set; } = new Uri("https://graph.microsoft.com/v1.0/");
     }
 }

--- a/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineFileManager.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineFileManager.cs
@@ -31,6 +31,7 @@ namespace Csrs.Interfaces
         private readonly Dictionary<string, string> _driveIdCache = new(StringComparer.OrdinalIgnoreCase);
 
         private string _siteId;
+        private HttpClient _httpClient;
 
         public SharePointOnlineFileManager(
             SharePointOnlineConfiguration configuration,
@@ -52,8 +53,7 @@ namespace Csrs.Interfaces
                 ? $"drives/{driveId}/root/children"
                 : $"drives/{driveId}/{EncodeGraphPath(folderName)}/children";
 
-            using var httpClient = await GetHttpClientAsync();
-            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Get, requestPath);
+            using var response = await SendGraphRequestAsync(HttpMethod.Get, requestPath);
 
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
@@ -100,8 +100,7 @@ namespace Csrs.Interfaces
             };
 
             string requestPath = $"drives/{driveId}/root/children";
-            using var httpClient = await GetHttpClientAsync();
-            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Post, requestPath, body);
+            using var response = await SendGraphRequestAsync(HttpMethod.Post, requestPath, body);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -123,8 +122,7 @@ namespace Csrs.Interfaces
             };
 
             string requestPath = "lists";
-            using var httpClient = await GetHttpClientAsync();
-            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Post, requestPath, body);
+            using var response = await SendGraphRequestAsync(HttpMethod.Post, requestPath, body);
             string responseContent = await ReadSuccessResponseAsync(response, HttpMethod.Post, requestPath, HttpStatusCode.Created);
             var createdList = JObject.Parse(responseContent);
 
@@ -133,7 +131,6 @@ namespace Csrs.Interfaces
                 string listId = createdList["id"]?.ToString();
                 var updateBody = new JObject { ["displayName"] = listTitle };
                 using var updateResponse = await SendGraphRequestAsync(
-                    httpClient,
                     HttpMethod.Patch,
                     $"lists/{listId}",
                     updateBody);
@@ -157,8 +154,7 @@ namespace Csrs.Interfaces
             var driveId = await GetDriveIdAsync(listTitle);
             string requestPath = $"drives/{driveId}/{EncodeGraphPath(folderName)}";
 
-            using var httpClient = await GetHttpClientAsync();
-            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Delete, requestPath);
+            using var response = await SendGraphRequestAsync(HttpMethod.Delete, requestPath);
 
             if (response.StatusCode == HttpStatusCode.NoContent)
             {
@@ -185,8 +181,7 @@ namespace Csrs.Interfaces
             var driveId = await GetDriveIdAsync(listTitle);
             string requestPath = $"drives/{driveId}/{EncodeGraphPath(folderName)}";
 
-            using var httpClient = await GetHttpClientAsync();
-            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Get, requestPath);
+            using var response = await SendGraphRequestAsync(HttpMethod.Get, requestPath);
 
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
@@ -275,14 +270,13 @@ namespace Csrs.Interfaces
             string itemPath = BuildItemPath(folderName, fileName);
             string requestPath = $"drives/{driveId}/{EncodeGraphPath(itemPath)}/content";
 
-            using var httpClient = await GetHttpClientAsync();
-            using var request = await CreateGraphRequestAsync(httpClient, HttpMethod.Put, requestPath);
-
+            using var request = await CreateSiteGraphRequestAsync(HttpMethod.Put, requestPath);
             var byteArrayContent = new ByteArrayContent(data);
             byteArrayContent.Headers.ContentType = new MediaTypeHeaderValue(
                 string.IsNullOrWhiteSpace(contentType) ? "application/octet-stream" : contentType);
             request.Content = byteArrayContent;
 
+            var httpClient = await GetHttpClientAsync();
             using var response = await httpClient.SendAsync(request);
             if (response.StatusCode is HttpStatusCode.OK or HttpStatusCode.Created)
             {
@@ -315,8 +309,7 @@ namespace Csrs.Interfaces
             };
 
             string requestPath = $"lists/{listId}/items/{itemId}/fields";
-            using var httpClient = await GetHttpClientAsync();
-            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Patch, requestPath, body);
+            using var response = await SendGraphRequestAsync(HttpMethod.Patch, requestPath, body);
             return await ReadSuccessResponseAsync(response, HttpMethod.Patch, requestPath);
         }
 
@@ -326,8 +319,7 @@ namespace Csrs.Interfaces
             var driveId = await GetDriveIdAsync(libraryName);
             string requestPath = $"drives/{driveId}/{EncodeGraphPath(itemPath)}/content";
 
-            using var httpClient = await GetHttpClientAsync();
-            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Get, requestPath);
+            using var response = await SendGraphRequestAsync(HttpMethod.Get, requestPath);
             await EnsureSuccessAsync(response, HttpMethod.Get, requestPath);
 
             using var ms = new MemoryStream();
@@ -347,8 +339,7 @@ namespace Csrs.Interfaces
             var driveId = await GetDriveIdAsync(libraryName);
             string requestPath = $"drives/{driveId}/{EncodeGraphPath(itemPath)}";
 
-            using var httpClient = await GetHttpClientAsync();
-            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Delete, requestPath);
+            using var response = await SendGraphRequestAsync(HttpMethod.Delete, requestPath);
 
             if (response.StatusCode == HttpStatusCode.NoContent)
             {
@@ -373,14 +364,12 @@ namespace Csrs.Interfaces
             var driveId = await GetDriveIdAsync(oldLibrary);
             string requestPath = $"drives/{driveId}/{EncodeGraphPath(oldItemPath)}";
 
-            using var httpClient = await GetHttpClientAsync();
-            using var getResponse = await SendGraphRequestAsync(httpClient, HttpMethod.Get, requestPath);
+            using var getResponse = await SendGraphRequestAsync(HttpMethod.Get, requestPath);
             string itemJson = await ReadSuccessResponseAsync(getResponse, HttpMethod.Get, requestPath);
             string itemId = JObject.Parse(itemJson)["id"]?.ToString();
 
             var body = new JObject { ["name"] = newFileName };
             using var patchResponse = await SendGraphRequestAsync(
-                httpClient,
                 HttpMethod.Patch,
                 $"drives/{driveId}/items/{itemId}",
                 body);
@@ -396,6 +385,11 @@ namespace Csrs.Interfaces
 
         private async Task<HttpClient> GetHttpClientAsync()
         {
+            if (_httpClient != null)
+            {
+                return _httpClient;
+            }
+
 #pragma warning disable CA2000 // Dispose objects before losing scope
             HttpMessageHandler handler = new SocketsHttpHandler
             {
@@ -404,16 +398,13 @@ namespace Csrs.Interfaces
             };
 #pragma warning restore CA2000
 
-            var httpClient = new HttpClient(handler)
-            {
-                BaseAddress = _configuration.GraphBaseUri,
-            };
-            httpClient.DefaultRequestHeaders.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+            _httpClient = new HttpClient(handler);
+            _httpClient.DefaultRequestHeaders.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
             string accessToken = await _authenticator.GetAccessTokenAsync();
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
-            return httpClient;
+            return _httpClient;
         }
 
         private async Task<string> GetSiteIdAsync()
@@ -430,10 +421,18 @@ namespace Csrs.Interfaces
                 sitePath = "/";
             }
 
-            string requestPath = $"sites/{resourceUri.Host}:{sitePath}";
-            using var httpClient = await GetHttpClientAsync();
-            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Get, requestPath);
-            string responseContent = await ReadSuccessResponseAsync(response, HttpMethod.Get, requestPath);
+            // Site lookup must not go through CreateSiteGraphRequestAsync (which requires a site id).
+            string siteLookupPath = $"sites/{resourceUri.Host}:{sitePath}";
+            var httpClient = await GetHttpClientAsync();
+            using var request = new HttpRequestMessage(HttpMethod.Get, BuildAbsoluteGraphUri(siteLookupPath));
+            using var response = await httpClient.SendAsync(request);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                await ThrowGraphExceptionAsync(response, HttpMethod.Get, siteLookupPath);
+            }
+
+            string responseContent = await response.Content.ReadAsStringAsync();
             _siteId = JObject.Parse(responseContent)["id"]?.ToString();
 
             if (string.IsNullOrEmpty(_siteId))
@@ -441,28 +440,47 @@ namespace Csrs.Interfaces
                 throw new SharePointRestException("Unable to resolve SharePoint site id from Microsoft Graph.");
             }
 
+            _logger.LogDebug(
+                "Resolved SharePoint site {SiteUrl} to Graph site id {SiteId}",
+                resourceUri,
+                _siteId);
+
             return _siteId;
         }
 
         private async Task<JToken> GetListAsync(string listTitle)
         {
-            string siteId = await GetSiteIdAsync();
-            using var httpClient = await GetHttpClientAsync();
-            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Get, "lists?$select=id,name,displayName,list");
-            string responseContent = await ReadSuccessResponseAsync(response, HttpMethod.Get, "lists");
+            await GetSiteIdAsync();
+            string requestPath = "lists?$select=id,name,displayName,list";
 
-            foreach (var list in ParseGraphCollection(responseContent))
+            do
             {
-                if (list["list"]?["template"]?.ToString() != "documentLibrary")
+                using var response = await SendGraphRequestAsync(HttpMethod.Get, requestPath);
+                string responseContent = await ReadSuccessResponseAsync(response, HttpMethod.Get, requestPath);
+                var responseObject = JObject.Parse(responseContent);
+
+                foreach (var list in ParseGraphCollection(responseContent))
                 {
-                    continue;
+                    if (list["list"]?["template"]?.ToString() != "documentLibrary")
+                    {
+                        continue;
+                    }
+
+                    if (MatchesListTitle(list, listTitle))
+                    {
+                        return list;
+                    }
                 }
 
-                if (MatchesListTitle(list, listTitle))
+                string nextLink = responseObject["@odata.nextLink"]?.ToString();
+                if (string.IsNullOrEmpty(nextLink))
                 {
-                    return list;
+                    break;
                 }
+
+                requestPath = GetGraphPathFromAbsoluteUri(new Uri(nextLink));
             }
+            while (true);
 
             return null;
         }
@@ -481,8 +499,7 @@ namespace Csrs.Interfaces
             }
 
             string listId = list["id"]?.ToString();
-            using var httpClient = await GetHttpClientAsync();
-            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Get, $"lists/{listId}/drive");
+            using var response = await SendGraphRequestAsync(HttpMethod.Get, $"lists/{listId}/drive");
             string responseContent = await ReadSuccessResponseAsync(response, HttpMethod.Get, $"lists/{listId}/drive");
             string driveId = JObject.Parse(responseContent)["id"]?.ToString();
 
@@ -501,26 +518,43 @@ namespace Csrs.Interfaces
                 || string.Equals(list["displayName"]?.ToString(), listTitle, StringComparison.OrdinalIgnoreCase);
         }
 
-        private async Task<HttpRequestMessage> CreateGraphRequestAsync(HttpClient httpClient, HttpMethod method, string relativePath)
+        private async Task<HttpRequestMessage> CreateSiteGraphRequestAsync(HttpMethod method, string siteRelativePath)
         {
             string siteId = await GetSiteIdAsync();
-            var request = new HttpRequestMessage(method, $"sites/{siteId}/{relativePath}");
-            return request;
+            return new HttpRequestMessage(method, BuildAbsoluteGraphUri($"sites/{siteId}/{siteRelativePath}"));
         }
 
         private async Task<HttpResponseMessage> SendGraphRequestAsync(
-            HttpClient httpClient,
             HttpMethod method,
-            string relativePath,
+            string siteRelativePath,
             JObject body = null)
         {
-            var request = await CreateGraphRequestAsync(httpClient, method, relativePath);
+            var request = await CreateSiteGraphRequestAsync(method, siteRelativePath);
             if (body != null)
             {
                 request.Content = new StringContent(body.ToString(Formatting.None), Encoding.UTF8, "application/json");
             }
 
+            var httpClient = await GetHttpClientAsync();
             return await httpClient.SendAsync(request);
+        }
+
+        private Uri BuildAbsoluteGraphUri(string graphPath)
+        {
+            string baseUrl = _configuration.GraphBaseUri.ToString().TrimEnd('/');
+            return new Uri($"{baseUrl}/{graphPath}");
+        }
+
+        private string GetGraphPathFromAbsoluteUri(Uri absoluteUri)
+        {
+            string baseUrl = _configuration.GraphBaseUri.ToString().TrimEnd('/');
+            string absolutePath = absoluteUri.ToString();
+            if (absolutePath.StartsWith(baseUrl, StringComparison.OrdinalIgnoreCase))
+            {
+                return absolutePath.Substring(baseUrl.Length).TrimStart('/');
+            }
+
+            return absoluteUri.AbsolutePath.TrimStart('/');
         }
 
         private static List<JToken> ParseGraphCollection(string responseContent)
@@ -568,6 +602,13 @@ namespace Csrs.Interfaces
             string responseContent = response.Content == null
                 ? string.Empty
                 : await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            _logger.LogError(
+                "Microsoft Graph request failed. Method={Method} Path={Path} StatusCode={StatusCode} Response={Response}",
+                method,
+                relativePath,
+                response.StatusCode,
+                responseContent);
 
             var ex = new SharePointRestException(
                 $"Microsoft Graph operation returned an invalid status code '{response.StatusCode}'");

--- a/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineFileManager.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineFileManager.cs
@@ -320,11 +320,25 @@ namespace Csrs.Interfaces
             string requestPath = $"drives/{driveId}/{EncodeGraphPath(itemPath)}/content";
 
             using var response = await SendGraphRequestAsync(HttpMethod.Get, requestPath);
-            await EnsureSuccessAsync(response, HttpMethod.Get, requestPath);
 
-            using var ms = new MemoryStream();
-            await response.Content.CopyToAsync(ms);
-            return ms.ToArray();
+            if (IsRedirectStatusCode(response.StatusCode))
+            {
+                Uri redirectUri = response.Headers.Location;
+                if (redirectUri == null)
+                {
+                    await ThrowGraphExceptionAsync(response, HttpMethod.Get, requestPath);
+                }
+
+                if (!redirectUri.IsAbsoluteUri && response.RequestMessage?.RequestUri != null)
+                {
+                    redirectUri = new Uri(response.RequestMessage.RequestUri, redirectUri);
+                }
+
+                return await DownloadFromRedirectUrlAsync(redirectUri);
+            }
+
+            await EnsureSuccessAsync(response, HttpMethod.Get, requestPath);
+            return await ReadResponseBytesAsync(response);
         }
 
         public async Task<bool> DeleteFile(string listTitle, string folderName, string fileName)
@@ -537,6 +551,32 @@ namespace Csrs.Interfaces
 
             var httpClient = await GetHttpClientAsync();
             return await httpClient.SendAsync(request);
+        }
+
+        private static bool IsRedirectStatusCode(HttpStatusCode statusCode)
+        {
+            return statusCode is HttpStatusCode.Redirect
+                or HttpStatusCode.MovedPermanently
+                or HttpStatusCode.SeeOther
+                or HttpStatusCode.TemporaryRedirect
+                or HttpStatusCode.PermanentRedirect;
+        }
+
+        private static async Task<byte[]> DownloadFromRedirectUrlAsync(Uri redirectUri)
+        {
+            // Graph returns a pre-authenticated download URL; do not send the Graph bearer token.
+            using var handler = new SocketsHttpHandler { AllowAutoRedirect = true };
+            using var client = new HttpClient(handler);
+            using var response = await client.GetAsync(redirectUri);
+            response.EnsureSuccessStatusCode();
+            return await ReadResponseBytesAsync(response);
+        }
+
+        private static async Task<byte[]> ReadResponseBytesAsync(HttpResponseMessage response)
+        {
+            using var ms = new MemoryStream();
+            await response.Content.CopyToAsync(ms);
+            return ms.ToArray();
         }
 
         private Uri BuildAbsoluteGraphUri(string graphPath)

--- a/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineFileManager.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineFileManager.cs
@@ -1,0 +1,698 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Rest;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace Csrs.Interfaces
+{
+    /// <summary>
+    /// SharePoint file manager implementation for SharePoint Online (SPO).
+    /// Uses OAuth2 client credentials (bearer token) for authentication
+    /// rather than the SAML / FedAuth cookie flow used by the on-premises implementation.
+    /// </summary>
+    public class SharePointOnlineFileManager : ISharePointFileManager
+    {
+        private const string DefaultDocumentListTitle = "Account";
+        private const string SharePointSpaceCharacter = "_x0020_";
+        private const int MaxUrlLength = 256;
+
+        private readonly SharePointOnlineConfiguration _configuration;
+        private readonly ISharePointOnlineAuthenticator _authenticator;
+        private readonly ILogger<SharePointOnlineFileManager> _logger;
+
+        public SharePointOnlineFileManager(
+            SharePointOnlineConfiguration configuration,
+            ISharePointOnlineAuthenticator authenticator,
+            ILogger<SharePointOnlineFileManager> logger)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _authenticator = authenticator ?? throw new ArgumentNullException(nameof(authenticator));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<List<FileDetailsList>> GetFileDetailsListInFolder(string listTitle, string folderName, string documentType)
+        {
+            folderName = FixFoldername(folderName);
+
+            string serverRelativeUrl = Uri.EscapeUriString(listTitle);
+            if (!string.IsNullOrEmpty(folderName))
+            {
+                serverRelativeUrl += "/" + Uri.EscapeUriString(folderName);
+            }
+            serverRelativeUrl = EscapeApostrophe(serverRelativeUrl);
+
+            string responseContent = null;
+            using var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+                RequestUri = new Uri(_configuration.Resource, $"_api/web/getFolderByServerRelativeUrl('/{serverRelativeUrl}')/files"),
+                Headers = { { "Accept", "application/json" } }
+            };
+
+            using var httpClient = await GetHttpClientAsync();
+            HttpResponseMessage response = null;
+            List<FileDetailsList> fileDetailsList = new List<FileDetailsList>();
+
+            try
+            {
+                response = await httpClient.SendAsync(request);
+            }
+            catch (ArgumentNullException)
+            {
+                var ex = new SharePointRestException("The response is null.");
+                ex.Request = new HttpRequestMessageWrapper(request, null);
+                ex.Response = new HttpResponseMessageWrapper(response, null);
+                _logger.LogError("The response is null.");
+                throw ex;
+            }
+            catch (InvalidOperationException)
+            {
+                var ex = new SharePointRestException("The request message was already sent by the HttpClient instance.");
+                ex.Request = new HttpRequestMessageWrapper(request, null);
+                ex.Response = new HttpResponseMessageWrapper(response, null);
+                _logger.LogError("The request message was already sent by the HttpClient instance.");
+                throw ex;
+            }
+            catch (HttpRequestException)
+            {
+                var ex = new SharePointRestException("The request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or timeout.");
+                ex.Request = new HttpRequestMessageWrapper(request, null);
+                ex.Response = new HttpResponseMessageWrapper(response, null);
+                _logger.LogError("The request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or timeout.");
+                throw ex;
+            }
+            catch (TaskCanceledException)
+            {
+                var ex = new SharePointRestException("The request failed due to timeout.");
+                ex.Request = new HttpRequestMessageWrapper(request, null);
+                ex.Response = new HttpResponseMessageWrapper(response, null);
+                _logger.LogError("The request failed due to timeout.");
+                throw ex;
+            }
+
+            HttpStatusCode statusCode = response.StatusCode;
+
+            if ((int)statusCode == 404)
+            {
+                _logger.LogInformation("The folder '{ServerRelativeUrl}' is not found.", serverRelativeUrl);
+                return fileDetailsList;
+            }
+
+            if ((int)statusCode != 200)
+            {
+                var ex = new SharePointRestException($"Operation returned an invalid status code '{statusCode}'");
+                responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                ex.Request = new HttpRequestMessageWrapper(request, null);
+                ex.Response = new HttpResponseMessageWrapper(response, responseContent);
+                throw ex;
+            }
+            else
+            {
+                responseContent = await response.Content.ReadAsStringAsync();
+            }
+
+            JObject responseObject = null;
+            try
+            {
+                responseObject = JObject.Parse(responseContent);
+            }
+            catch (JsonReaderException jre)
+            {
+                _logger.LogError("Error parsing response: {Content}", responseContent);
+                throw jre;
+            }
+
+            List<JToken> responseResults = responseObject["value"].Children().ToList();
+            foreach (JToken responseResult in responseResults)
+            {
+                FileDetailsList searchResult = responseResult.ToObject<FileDetailsList>();
+                string fileDoctype = Path.GetExtension(searchResult.Name).ToUpper();
+                searchResult.DocumentType = fileDoctype ?? string.Empty;
+                fileDetailsList.Add(searchResult);
+            }
+
+            return fileDetailsList;
+        }
+
+        public async Task CreateFolder(string listTitle, string folderName)
+        {
+            folderName = FixFoldername(folderName);
+            string relativeUrl = EscapeApostrophe($"/{listTitle}/{folderName}");
+
+            using var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                RequestUri = new Uri(_configuration.Resource, $"_api/web/folders/add('{relativeUrl}')"),
+                Headers = { { "Accept", "application/json" } }
+            };
+
+            StringContent strContent = new StringContent("", Encoding.UTF8);
+            strContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json;odata=verbose");
+            request.Content = strContent;
+
+            using var httpClient = await GetHttpClientAsync();
+            using var response = await httpClient.SendAsync(request);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var ex = new SharePointRestException($"Operation returned an invalid status code '{response.StatusCode}'");
+                string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                ex.Request = new HttpRequestMessageWrapper(request, null);
+                ex.Response = new HttpResponseMessageWrapper(response, responseContent);
+                throw ex;
+            }
+        }
+
+        public async Task<object> CreateDocumentLibrary(string listTitle, string documentTemplateUrlTitle = null)
+        {
+            using var listsRequest = new HttpRequestMessage(HttpMethod.Post, new Uri(_configuration.Resource, "_api/web/Lists"));
+
+            if (string.IsNullOrEmpty(documentTemplateUrlTitle))
+            {
+                documentTemplateUrlTitle = listTitle;
+            }
+
+            var library = CreateNewDocumentLibraryRequest(documentTemplateUrlTitle);
+            string jsonString = JsonConvert.SerializeObject(library);
+            StringContent strContent = new StringContent(jsonString, Encoding.UTF8);
+            strContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json;odata=verbose");
+            listsRequest.Content = strContent;
+            listsRequest.Headers.Add("odata-version", "3.0");
+
+            using var httpClient = await GetHttpClientAsync();
+            using var listsResponse = await httpClient.SendAsync(listsRequest);
+            HttpStatusCode statusCode = listsResponse.StatusCode;
+
+            if (statusCode != HttpStatusCode.Created || !listsResponse.IsSuccessStatusCode)
+            {
+                var ex = new SharePointRestException($"Operation returned an invalid status code '{statusCode}'");
+                string responseContent = await listsResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                ex.Request = new HttpRequestMessageWrapper(listsRequest, null);
+                ex.Response = new HttpResponseMessageWrapper(listsResponse, responseContent);
+                throw ex;
+            }
+            else
+            {
+                jsonString = await listsResponse.Content.ReadAsStringAsync();
+                var ob = JsonConvert.DeserializeObject<DocumentLibraryResponse>(jsonString);
+
+                if (listTitle != documentTemplateUrlTitle)
+                {
+                    using var titleRequest = new HttpRequestMessage(HttpMethod.Post, new Uri(_configuration.Resource, $"_api/web/lists(guid'{ob.d.Id}')"));
+                    var updateRequest = new
+                    {
+                        __metadata = new { type = "SP.List" },
+                        Title = listTitle
+                    };
+                    jsonString = JsonConvert.SerializeObject(updateRequest);
+                    strContent = new StringContent(jsonString, Encoding.UTF8);
+                    strContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json;odata=verbose");
+                    titleRequest.Headers.Add("IF-MATCH", "*");
+                    titleRequest.Headers.Add("X-HTTP-Method", "MERGE");
+                    titleRequest.Content = strContent;
+
+                    using var titleResponse = await httpClient.SendAsync(titleRequest);
+                    titleResponse.EnsureSuccessStatusCode();
+                }
+            }
+
+            return library;
+        }
+
+        public async Task<object> UpdateDocumentLibrary(string listTitle)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Put, new Uri(_configuration.Resource, "_api/web/Lists"));
+
+            var library = CreateNewDocumentLibraryRequest(listTitle);
+            string jsonString = JsonConvert.SerializeObject(library);
+            StringContent strContent = new StringContent(jsonString, Encoding.UTF8);
+            strContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json;odata=verbose");
+            request.Content = strContent;
+
+            using var httpClient = await GetHttpClientAsync();
+            using var response = await httpClient.SendAsync(request);
+            HttpStatusCode statusCode = response.StatusCode;
+
+            if (statusCode != HttpStatusCode.Created || !response.IsSuccessStatusCode)
+            {
+                var ex = new SharePointRestException($"Operation returned an invalid status code '{statusCode}'");
+                string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                ex.Request = new HttpRequestMessageWrapper(request, null);
+                ex.Response = new HttpResponseMessageWrapper(response, responseContent);
+                throw ex;
+            }
+
+            return library;
+        }
+
+        public async Task<bool> DeleteFolder(string listTitle, string folderName)
+        {
+            folderName = FixFoldername(folderName);
+            string serverRelativeUrl = $"{listTitle}/{folderName}";
+
+            using var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Delete,
+                RequestUri = new Uri(_configuration.Resource, "_api/web/getFolderByServerRelativeUrl('/" + EscapeApostrophe(serverRelativeUrl) + "')"),
+                Headers = { { "Accept", "application/json" } }
+            };
+            request.Headers.Add("IF-MATCH", "*");
+            request.Headers.Add("X-HTTP-Method", "DELETE");
+
+            using var httpClient = await GetHttpClientAsync();
+            using var response = await httpClient.SendAsync(request);
+
+            if (response.StatusCode == HttpStatusCode.NoContent)
+            {
+                return true;
+            }
+
+            var ex2 = new SharePointRestException($"Operation returned an invalid status code '{response.StatusCode}'");
+            string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            ex2.Request = new HttpRequestMessageWrapper(request, null);
+            ex2.Response = new HttpResponseMessageWrapper(response, content);
+            throw ex2;
+        }
+
+        public async Task<bool> FolderExists(string listTitle, string folderName)
+        {
+            var folder = await GetFolder(listTitle, folderName);
+            return folder != null;
+        }
+
+        public async Task<bool> DocumentLibraryExists(string listTitle)
+        {
+            var library = await GetDocumentLibrary(listTitle);
+            return library != null;
+        }
+
+        public async Task<object> GetFolder(string listTitle, string folderName)
+        {
+            folderName = FixFoldername(folderName);
+            string serverRelativeUrl = $"{listTitle}/{folderName}";
+
+            using var endpointRequest = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+                RequestUri = new Uri(_configuration.Resource, "_api/web/getFolderByServerRelativeUrl('/" + EscapeApostrophe(serverRelativeUrl) + "')"),
+                Headers = { { "Accept", "application/json" } }
+            };
+
+            using var httpClient = await GetHttpClientAsync();
+            using var response = await httpClient.SendAsync(endpointRequest);
+            string jsonString = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode == HttpStatusCode.OK || response.IsSuccessStatusCode)
+            {
+                return JsonConvert.DeserializeObject(jsonString);
+            }
+
+            return null;
+        }
+
+        public async Task<object> GetDocumentLibrary(string listTitle)
+        {
+            string title = Uri.EscapeUriString(listTitle);
+
+            using var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+                RequestUri = new Uri(_configuration.Resource, $"_api/web/lists/GetByTitle('{title}')"),
+                Headers = { { "Accept", "application/json" } }
+            };
+
+            using var httpClient = await GetHttpClientAsync();
+            using var response = await httpClient.SendAsync(request);
+            string jsonString = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                return JsonConvert.DeserializeObject(jsonString);
+            }
+
+            return null;
+        }
+
+        public async Task<string> AddFile(string folderName, string fileName, Stream fileData, string contentType)
+        {
+            return await AddFile(DefaultDocumentListTitle, folderName, fileName, fileData, contentType);
+        }
+
+        public async Task<string> AddFile(string documentLibrary, string folderName, string fileName, Stream fileData, string contentType)
+        {
+            folderName = FixFoldername(folderName);
+            bool folderExists = await FolderExists(documentLibrary, folderName);
+            if (!folderExists)
+            {
+                await CreateFolder(documentLibrary, folderName);
+            }
+            return await UploadFile(fileName, documentLibrary, folderName, fileData, contentType);
+        }
+
+        public async Task<string> AddFile(string folderName, string fileName, byte[] fileData, string contentType)
+        {
+            return await AddFile(DefaultDocumentListTitle, folderName, fileName, fileData, contentType);
+        }
+
+        public async Task<string> AddFile(string documentLibrary, string folderName, string fileName, byte[] fileData, string contentType)
+        {
+            folderName = FixFoldername(folderName);
+            bool folderExists = await FolderExists(documentLibrary, folderName);
+            if (!folderExists)
+            {
+                await CreateFolder(documentLibrary, folderName);
+            }
+            return await UploadFile(fileName, documentLibrary, folderName, fileData, contentType);
+        }
+
+        public async Task<string> UploadFile(string fileName, string listTitle, string folderName, Stream fileData, string contentType)
+        {
+            using var ms = new MemoryStream();
+            fileData.CopyTo(ms);
+            byte[] data = ms.ToArray();
+            return await UploadFile(fileName, listTitle, folderName, data, contentType);
+        }
+
+        public string GetTruncatedFileName(string fileName, string listTitle, string folderName)
+        {
+            int maxLength = 128;
+            fileName = FixFilename(fileName, maxLength);
+            folderName = FixFoldername(folderName);
+
+            string serverRelativeUrl = GetServerRelativeURL(listTitle, folderName);
+            string requestUriString = GenerateUploadRequestUriString(serverRelativeUrl, fileName);
+
+            if (requestUriString.Length > MaxUrlLength)
+            {
+                int delta = requestUriString.Length - MaxUrlLength;
+                maxLength -= delta;
+                fileName = FixFilename(fileName, maxLength);
+            }
+
+            return fileName;
+        }
+
+        public async Task<string> UploadFile(string fileName, string listTitle, string folderName, byte[] data, string contentType)
+        {
+            folderName = FixFoldername(folderName);
+            fileName = GetTruncatedFileName(fileName, listTitle, folderName);
+
+            string serverRelativeUrl = GetServerRelativeURL(listTitle, folderName);
+            string requestUriString = GenerateUploadRequestUriString(serverRelativeUrl, fileName);
+
+            using var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                RequestUri = new Uri(requestUriString),
+                Headers = { { "Accept", "application/json" } }
+            };
+
+            ByteArrayContent byteArrayContent = new ByteArrayContent(data);
+            byteArrayContent.Headers.Add("content-length", data.Length.ToString());
+            request.Content = byteArrayContent;
+
+            using var httpClient = await GetHttpClientAsync();
+            using var response = await httpClient.SendAsync(request);
+
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                return fileName;
+            }
+
+            var ex = new SharePointRestException($"Operation returned an invalid status code '{response.StatusCode}'");
+            string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            ex.Request = new HttpRequestMessageWrapper(request, null);
+            ex.Response = new HttpResponseMessageWrapper(response, responseContent);
+            throw ex;
+        }
+
+        public async Task<string> UpdateListItemFields(AddFileResponse itemData, string listTitle, string contentType, string fileName)
+        {
+            string requestUriString = GenerateUpdateListItemUriString(listTitle, itemData.ListItemAllFields.ID.ToString());
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, requestUriString);
+
+            var listItem = CreateUpdateListItemRequestRequest(contentType, fileName, listTitle);
+            string jsonString = JsonConvert.SerializeObject(listItem);
+            StringContent strContent = new StringContent(jsonString, Encoding.UTF8);
+            strContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json;odata=verbose");
+
+            request.Headers.Add("Accept", "application/json;odata=verbose");
+            request.Headers.Add("X-Http-Method", "MERGE");
+            request.Headers.Add("IF-MATCH", "*");
+            request.Headers.Add("odata-version", "3.0");
+            request.Content = strContent;
+
+            using var httpClient = await GetHttpClientAsync();
+            using var response = await httpClient.SendAsync(request);
+            string streamData = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.NoContent)
+            {
+                return streamData;
+            }
+
+            var ex = new SharePointRestException($"Operation returned an invalid status code '{response.StatusCode}'");
+            string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            ex.Request = new HttpRequestMessageWrapper(request, null);
+            ex.Response = new HttpResponseMessageWrapper(response, responseContent);
+            throw ex;
+        }
+
+        public async Task<byte[]> DownloadFile(string url)
+        {
+            url = EscapeApostrophe(url);
+
+            using var endpointRequest = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+                RequestUri = new Uri(_configuration.Resource, $"_api/web/GetFileByServerRelativeUrl('{url}')/$value"),
+            };
+
+            using var httpClient = await GetHttpClientAsync();
+            using var response = await httpClient.SendAsync(endpointRequest);
+
+            using var ms = new MemoryStream();
+            await response.Content.CopyToAsync(ms);
+            return ms.ToArray();
+        }
+
+        public async Task<bool> DeleteFile(string listTitle, string folderName, string fileName)
+        {
+            folderName = FixFoldername(folderName);
+            string serverRelativeUrl = $"/{listTitle}/{folderName}/{fileName}";
+            return await DeleteFile(serverRelativeUrl);
+        }
+
+        public async Task<bool> DeleteFile(string serverRelativeUrl)
+        {
+            serverRelativeUrl = EscapeApostrophe(serverRelativeUrl);
+
+            using var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Delete,
+                RequestUri = new Uri(_configuration.Resource, $"_api/web/GetFileByServerRelativeUrl('/{serverRelativeUrl}')"),
+                Headers = { { "Accept", "application/json" } }
+            };
+            request.Headers.Add("IF-MATCH", "*");
+            request.Headers.Add("X-HTTP-Method", "DELETE");
+
+            using var httpClient = await GetHttpClientAsync();
+            using var response = await httpClient.SendAsync(request);
+
+            if (response.StatusCode == HttpStatusCode.NoContent)
+            {
+                return true;
+            }
+
+            var ex = new SharePointRestException($"Operation returned an invalid status code '{response.StatusCode}'");
+            string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            ex.Request = new HttpRequestMessageWrapper(request, null);
+            ex.Response = new HttpResponseMessageWrapper(response, responseContent);
+            throw ex;
+        }
+
+        public async Task<bool> RenameFile(string oldServerRelativeUrl, string newServerRelativeUrl)
+        {
+            oldServerRelativeUrl = EscapeApostrophe(oldServerRelativeUrl);
+            newServerRelativeUrl = EscapeApostrophe(newServerRelativeUrl);
+
+            Uri url = new Uri(_configuration.Resource, $"_api/web/GetFileByServerRelativeUrl('{oldServerRelativeUrl}')/moveto(newurl='{newServerRelativeUrl}', flags=1)");
+            using var request = new HttpRequestMessage(HttpMethod.Post, url);
+
+            using var httpClient = await GetHttpClientAsync();
+            using var response = await httpClient.SendAsync(request);
+
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                return true;
+            }
+
+            var ex = new SharePointRestException($"Operation returned an invalid status code '{response.StatusCode}'");
+            string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            ex.Request = new HttpRequestMessageWrapper(request, null);
+            ex.Response = new HttpResponseMessageWrapper(response, responseContent);
+            throw ex;
+        }
+
+        private async Task<HttpClient> GetHttpClientAsync()
+        {
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            HttpMessageHandler handler = new SocketsHttpHandler
+            {
+                AllowAutoRedirect = false,
+                MaxConnectionsPerServer = 25
+            };
+#pragma warning restore CA2000
+
+            HttpClient httpClient = new HttpClient(handler);
+            httpClient.BaseAddress = _configuration.Resource;
+            httpClient.DefaultRequestHeaders.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata=verbose"));
+
+            string accessToken = await _authenticator.GetAccessTokenAsync();
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+            string digest = await GetDigest(httpClient);
+            if (digest is not null)
+            {
+                httpClient.DefaultRequestHeaders.Add("X-RequestDigest", digest);
+            }
+
+            httpClient.DefaultRequestHeaders.Add("Cache-Control", "no-cache");
+            httpClient.DefaultRequestHeaders.Add("OData-Version", "4.0");
+
+            return httpClient;
+        }
+
+        private async Task<string> GetDigest(HttpClient client)
+        {
+            string result = null;
+
+            using var endpointRequest = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                RequestUri = new Uri(_configuration.Resource, "_api/contextinfo"),
+                Headers = { { "Accept", "application/json;odata=verbose" } }
+            };
+
+            var response = await client.SendAsync(endpointRequest);
+            string jsonString = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode == HttpStatusCode.OK && jsonString.Length > 1)
+            {
+                if (jsonString[0] == '{')
+                {
+                    JToken t = JToken.Parse(jsonString);
+                    result = t["d"]["GetContextWebInformation"]["FormDigestValue"].ToString();
+                }
+                else
+                {
+                    XmlDocument doc = new XmlDocument();
+                    doc.LoadXml(jsonString);
+                    var digests = doc.GetElementsByTagName("d:FormDigestValue");
+                    if (digests.Count > 0)
+                    {
+                        result = digests[0].InnerText;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private static string EscapeApostrophe(string value)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                return value.Replace("'", "''");
+            }
+            return value;
+        }
+
+        private string GetInvalidCharacters(string osInvalidChars)
+        {
+            osInvalidChars += "~#%&*()[]{}:;+@^<>|.?!/";
+            string invalidChars = Regex.Escape(osInvalidChars);
+            return string.Format(@"([{0}]*\.+$)|([{0}]+)", invalidChars);
+        }
+
+        private string RemoveInvalidCharacters(string filename)
+        {
+            var osInvalidChars = new string(Path.GetInvalidFileNameChars());
+            return Regex.Replace(filename, GetInvalidCharacters(osInvalidChars), "_");
+        }
+
+        private string FixFoldername(string foldername)
+        {
+            var osInvalidChars = new string(Path.GetInvalidPathChars());
+            return Regex.Replace(foldername, GetInvalidCharacters(osInvalidChars), "_");
+        }
+
+        private string FixFilename(string filename, int maxLength = 128)
+        {
+            string result = RemoveInvalidCharacters(filename);
+            if (result.Length >= maxLength)
+            {
+                string extension = Path.GetExtension(result);
+                result = Path.GetFileNameWithoutExtension(result).Substring(0, maxLength - extension.Length);
+                result += extension;
+            }
+            return result;
+        }
+
+        private string GetServerRelativeURL(string listTitle, string folderName)
+        {
+            folderName = FixFoldername(folderName);
+            return Uri.EscapeUriString(listTitle) + "/" + Uri.EscapeUriString(folderName);
+        }
+
+        private string GenerateUploadRequestUriString(string folderServerRelativeUrl, string fileName)
+        {
+            folderServerRelativeUrl = EscapeApostrophe(folderServerRelativeUrl);
+            fileName = EscapeApostrophe(fileName);
+            Uri requestUri = new Uri(_configuration.Resource, $"_api/web/getFolderByServerRelativeUrl('/{folderServerRelativeUrl}')/Files/add(url='{fileName}',overwrite=true)?$expand=ListItemAllFields");
+            return requestUri.ToString();
+        }
+
+        private string GenerateUpdateListItemUriString(string listTitle, string id)
+        {
+            listTitle = EscapeApostrophe(listTitle);
+            id = EscapeApostrophe(id);
+            Uri requestUri = new Uri(_configuration.Resource, $"_api/web/lists/getbytitle('{listTitle}')/items({id})");
+            return requestUri.ToString();
+        }
+
+        private static object CreateNewDocumentLibraryRequest(string listName)
+        {
+            return new
+            {
+                __metadata = new { type = "SP.List" },
+                BaseTemplate = 101,
+                Title = listName
+            };
+        }
+
+        private static object CreateUpdateListItemRequestRequest(string title, string fileName, string listTitle)
+        {
+            string formattedTitle = listTitle.Replace(" ", SharePointSpaceCharacter);
+            string itemType = $"SP.Data.{formattedTitle}Item";
+            return new
+            {
+                __metadata = new { type = itemType },
+                FileLeafRef = fileName,
+                Title = title
+            };
+        }
+    }
+}

--- a/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineFileManager.cs
+++ b/src/backend/Csrs.Interfaces.SharePoint/SharePointOnlineFileManager.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -12,24 +13,24 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using System.Xml;
 
 namespace Csrs.Interfaces
 {
     /// <summary>
     /// SharePoint file manager implementation for SharePoint Online (SPO).
-    /// Uses OAuth2 client credentials (bearer token) for authentication
-    /// rather than the SAML / FedAuth cookie flow used by the on-premises implementation.
+    /// Uses Microsoft Graph API with OAuth2 client credentials (application permissions).
     /// </summary>
     public class SharePointOnlineFileManager : ISharePointFileManager
     {
         private const string DefaultDocumentListTitle = "Account";
-        private const string SharePointSpaceCharacter = "_x0020_";
         private const int MaxUrlLength = 256;
 
         private readonly SharePointOnlineConfiguration _configuration;
         private readonly ISharePointOnlineAuthenticator _authenticator;
         private readonly ILogger<SharePointOnlineFileManager> _logger;
+        private readonly Dictionary<string, string> _driveIdCache = new(StringComparer.OrdinalIgnoreCase);
+
+        private string _siteId;
 
         public SharePointOnlineFileManager(
             SharePointOnlineConfiguration configuration,
@@ -44,102 +45,43 @@ namespace Csrs.Interfaces
         public async Task<List<FileDetailsList>> GetFileDetailsListInFolder(string listTitle, string folderName, string documentType)
         {
             folderName = FixFoldername(folderName);
+            var driveId = await GetDriveIdAsync(listTitle);
+            var fileDetailsList = new List<FileDetailsList>();
 
-            string serverRelativeUrl = Uri.EscapeUriString(listTitle);
-            if (!string.IsNullOrEmpty(folderName))
-            {
-                serverRelativeUrl += "/" + Uri.EscapeUriString(folderName);
-            }
-            serverRelativeUrl = EscapeApostrophe(serverRelativeUrl);
-
-            string responseContent = null;
-            using var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Get,
-                RequestUri = new Uri(_configuration.Resource, $"_api/web/getFolderByServerRelativeUrl('/{serverRelativeUrl}')/files"),
-                Headers = { { "Accept", "application/json" } }
-            };
+            string requestPath = string.IsNullOrEmpty(folderName)
+                ? $"drives/{driveId}/root/children"
+                : $"drives/{driveId}/{EncodeGraphPath(folderName)}/children";
 
             using var httpClient = await GetHttpClientAsync();
-            HttpResponseMessage response = null;
-            List<FileDetailsList> fileDetailsList = new List<FileDetailsList>();
+            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Get, requestPath);
 
-            try
+            if (response.StatusCode == HttpStatusCode.NotFound)
             {
-                response = await httpClient.SendAsync(request);
-            }
-            catch (ArgumentNullException)
-            {
-                var ex = new SharePointRestException("The response is null.");
-                ex.Request = new HttpRequestMessageWrapper(request, null);
-                ex.Response = new HttpResponseMessageWrapper(response, null);
-                _logger.LogError("The response is null.");
-                throw ex;
-            }
-            catch (InvalidOperationException)
-            {
-                var ex = new SharePointRestException("The request message was already sent by the HttpClient instance.");
-                ex.Request = new HttpRequestMessageWrapper(request, null);
-                ex.Response = new HttpResponseMessageWrapper(response, null);
-                _logger.LogError("The request message was already sent by the HttpClient instance.");
-                throw ex;
-            }
-            catch (HttpRequestException)
-            {
-                var ex = new SharePointRestException("The request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or timeout.");
-                ex.Request = new HttpRequestMessageWrapper(request, null);
-                ex.Response = new HttpResponseMessageWrapper(response, null);
-                _logger.LogError("The request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or timeout.");
-                throw ex;
-            }
-            catch (TaskCanceledException)
-            {
-                var ex = new SharePointRestException("The request failed due to timeout.");
-                ex.Request = new HttpRequestMessageWrapper(request, null);
-                ex.Response = new HttpResponseMessageWrapper(response, null);
-                _logger.LogError("The request failed due to timeout.");
-                throw ex;
-            }
-
-            HttpStatusCode statusCode = response.StatusCode;
-
-            if ((int)statusCode == 404)
-            {
-                _logger.LogInformation("The folder '{ServerRelativeUrl}' is not found.", serverRelativeUrl);
+                _logger.LogInformation("The folder '{ListTitle}/{FolderName}' was not found.", listTitle, folderName);
                 return fileDetailsList;
             }
 
-            if ((int)statusCode != 200)
-            {
-                var ex = new SharePointRestException($"Operation returned an invalid status code '{statusCode}'");
-                responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                ex.Request = new HttpRequestMessageWrapper(request, null);
-                ex.Response = new HttpResponseMessageWrapper(response, responseContent);
-                throw ex;
-            }
-            else
-            {
-                responseContent = await response.Content.ReadAsStringAsync();
-            }
+            string responseContent = await ReadSuccessResponseAsync(response, HttpMethod.Get, requestPath);
+            var children = ParseGraphCollection(responseContent);
 
-            JObject responseObject = null;
-            try
+            foreach (var item in children)
             {
-                responseObject = JObject.Parse(responseContent);
-            }
-            catch (JsonReaderException jre)
-            {
-                _logger.LogError("Error parsing response: {Content}", responseContent);
-                throw jre;
-            }
+                if (item["file"] == null)
+                {
+                    continue;
+                }
 
-            List<JToken> responseResults = responseObject["value"].Children().ToList();
-            foreach (JToken responseResult in responseResults)
-            {
-                FileDetailsList searchResult = responseResult.ToObject<FileDetailsList>();
-                string fileDoctype = Path.GetExtension(searchResult.Name).ToUpper();
-                searchResult.DocumentType = fileDoctype ?? string.Empty;
-                fileDetailsList.Add(searchResult);
+                string name = item["name"]?.ToString();
+                var fileDetails = new FileDetailsList
+                {
+                    Name = name,
+                    Length = item["size"]?.ToString() ?? "0",
+                    TimeCreated = item["createdDateTime"]?.ToString(),
+                    TimeLastModified = item["lastModifiedDateTime"]?.ToString(),
+                    ServerRelativeUrl = BuildServerRelativeUrl(listTitle, folderName, name),
+                    DocumentType = Path.GetExtension(name)?.ToUpper(CultureInfo.InvariantCulture) ?? string.Empty,
+                };
+                fileDetailsList.Add(fileDetails);
             }
 
             return fileDetailsList;
@@ -148,173 +90,112 @@ namespace Csrs.Interfaces
         public async Task CreateFolder(string listTitle, string folderName)
         {
             folderName = FixFoldername(folderName);
-            string relativeUrl = EscapeApostrophe($"/{listTitle}/{folderName}");
+            var driveId = await GetDriveIdAsync(listTitle);
 
-            using var request = new HttpRequestMessage
+            var body = new JObject
             {
-                Method = HttpMethod.Post,
-                RequestUri = new Uri(_configuration.Resource, $"_api/web/folders/add('{relativeUrl}')"),
-                Headers = { { "Accept", "application/json" } }
+                ["name"] = folderName,
+                ["folder"] = new JObject(),
+                ["@microsoft.graph.conflictBehavior"] = "fail",
             };
 
-            StringContent strContent = new StringContent("", Encoding.UTF8);
-            strContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json;odata=verbose");
-            request.Content = strContent;
-
+            string requestPath = $"drives/{driveId}/root/children";
             using var httpClient = await GetHttpClientAsync();
-            using var response = await httpClient.SendAsync(request);
+            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Post, requestPath, body);
 
             if (!response.IsSuccessStatusCode)
             {
-                var ex = new SharePointRestException($"Operation returned an invalid status code '{response.StatusCode}'");
-                string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                ex.Request = new HttpRequestMessageWrapper(request, null);
-                ex.Response = new HttpResponseMessageWrapper(response, responseContent);
-                throw ex;
+                await ThrowGraphExceptionAsync(response, HttpMethod.Post, requestPath);
             }
         }
 
         public async Task<object> CreateDocumentLibrary(string listTitle, string documentTemplateUrlTitle = null)
         {
-            using var listsRequest = new HttpRequestMessage(HttpMethod.Post, new Uri(_configuration.Resource, "_api/web/Lists"));
-
             if (string.IsNullOrEmpty(documentTemplateUrlTitle))
             {
                 documentTemplateUrlTitle = listTitle;
             }
 
-            var library = CreateNewDocumentLibraryRequest(documentTemplateUrlTitle);
-            string jsonString = JsonConvert.SerializeObject(library);
-            StringContent strContent = new StringContent(jsonString, Encoding.UTF8);
-            strContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json;odata=verbose");
-            listsRequest.Content = strContent;
-            listsRequest.Headers.Add("odata-version", "3.0");
+            var body = new JObject
+            {
+                ["displayName"] = documentTemplateUrlTitle,
+                ["list"] = new JObject { ["template"] = "documentLibrary" },
+            };
 
+            string requestPath = "lists";
             using var httpClient = await GetHttpClientAsync();
-            using var listsResponse = await httpClient.SendAsync(listsRequest);
-            HttpStatusCode statusCode = listsResponse.StatusCode;
+            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Post, requestPath, body);
+            string responseContent = await ReadSuccessResponseAsync(response, HttpMethod.Post, requestPath, HttpStatusCode.Created);
+            var createdList = JObject.Parse(responseContent);
 
-            if (statusCode != HttpStatusCode.Created || !listsResponse.IsSuccessStatusCode)
+            if (!string.Equals(listTitle, documentTemplateUrlTitle, StringComparison.OrdinalIgnoreCase))
             {
-                var ex = new SharePointRestException($"Operation returned an invalid status code '{statusCode}'");
-                string responseContent = await listsResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                ex.Request = new HttpRequestMessageWrapper(listsRequest, null);
-                ex.Response = new HttpResponseMessageWrapper(listsResponse, responseContent);
-                throw ex;
-            }
-            else
-            {
-                jsonString = await listsResponse.Content.ReadAsStringAsync();
-                var ob = JsonConvert.DeserializeObject<DocumentLibraryResponse>(jsonString);
-
-                if (listTitle != documentTemplateUrlTitle)
-                {
-                    using var titleRequest = new HttpRequestMessage(HttpMethod.Post, new Uri(_configuration.Resource, $"_api/web/lists(guid'{ob.d.Id}')"));
-                    var updateRequest = new
-                    {
-                        __metadata = new { type = "SP.List" },
-                        Title = listTitle
-                    };
-                    jsonString = JsonConvert.SerializeObject(updateRequest);
-                    strContent = new StringContent(jsonString, Encoding.UTF8);
-                    strContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json;odata=verbose");
-                    titleRequest.Headers.Add("IF-MATCH", "*");
-                    titleRequest.Headers.Add("X-HTTP-Method", "MERGE");
-                    titleRequest.Content = strContent;
-
-                    using var titleResponse = await httpClient.SendAsync(titleRequest);
-                    titleResponse.EnsureSuccessStatusCode();
-                }
+                string listId = createdList["id"]?.ToString();
+                var updateBody = new JObject { ["displayName"] = listTitle };
+                using var updateResponse = await SendGraphRequestAsync(
+                    httpClient,
+                    HttpMethod.Patch,
+                    $"lists/{listId}",
+                    updateBody);
+                await ReadSuccessResponseAsync(updateResponse, HttpMethod.Patch, $"lists/{listId}");
             }
 
-            return library;
+            _driveIdCache.Remove(listTitle);
+            _driveIdCache.Remove(documentTemplateUrlTitle);
+
+            return body;
         }
 
         public async Task<object> UpdateDocumentLibrary(string listTitle)
         {
-            using var request = new HttpRequestMessage(HttpMethod.Put, new Uri(_configuration.Resource, "_api/web/Lists"));
-
-            var library = CreateNewDocumentLibraryRequest(listTitle);
-            string jsonString = JsonConvert.SerializeObject(library);
-            StringContent strContent = new StringContent(jsonString, Encoding.UTF8);
-            strContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json;odata=verbose");
-            request.Content = strContent;
-
-            using var httpClient = await GetHttpClientAsync();
-            using var response = await httpClient.SendAsync(request);
-            HttpStatusCode statusCode = response.StatusCode;
-
-            if (statusCode != HttpStatusCode.Created || !response.IsSuccessStatusCode)
-            {
-                var ex = new SharePointRestException($"Operation returned an invalid status code '{statusCode}'");
-                string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                ex.Request = new HttpRequestMessageWrapper(request, null);
-                ex.Response = new HttpResponseMessageWrapper(response, responseContent);
-                throw ex;
-            }
-
-            return library;
+            return await CreateDocumentLibrary(listTitle);
         }
 
         public async Task<bool> DeleteFolder(string listTitle, string folderName)
         {
             folderName = FixFoldername(folderName);
-            string serverRelativeUrl = $"{listTitle}/{folderName}";
-
-            using var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Delete,
-                RequestUri = new Uri(_configuration.Resource, "_api/web/getFolderByServerRelativeUrl('/" + EscapeApostrophe(serverRelativeUrl) + "')"),
-                Headers = { { "Accept", "application/json" } }
-            };
-            request.Headers.Add("IF-MATCH", "*");
-            request.Headers.Add("X-HTTP-Method", "DELETE");
+            var driveId = await GetDriveIdAsync(listTitle);
+            string requestPath = $"drives/{driveId}/{EncodeGraphPath(folderName)}";
 
             using var httpClient = await GetHttpClientAsync();
-            using var response = await httpClient.SendAsync(request);
+            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Delete, requestPath);
 
             if (response.StatusCode == HttpStatusCode.NoContent)
             {
                 return true;
             }
 
-            var ex2 = new SharePointRestException($"Operation returned an invalid status code '{response.StatusCode}'");
-            string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            ex2.Request = new HttpRequestMessageWrapper(request, null);
-            ex2.Response = new HttpResponseMessageWrapper(response, content);
-            throw ex2;
+            await ThrowGraphExceptionAsync(response, HttpMethod.Delete, requestPath);
+            return false;
         }
 
         public async Task<bool> FolderExists(string listTitle, string folderName)
         {
-            var folder = await GetFolder(listTitle, folderName);
-            return folder != null;
+            return await GetFolder(listTitle, folderName) != null;
         }
 
         public async Task<bool> DocumentLibraryExists(string listTitle)
         {
-            var library = await GetDocumentLibrary(listTitle);
-            return library != null;
+            return await GetDocumentLibrary(listTitle) != null;
         }
 
         public async Task<object> GetFolder(string listTitle, string folderName)
         {
             folderName = FixFoldername(folderName);
-            string serverRelativeUrl = $"{listTitle}/{folderName}";
-
-            using var endpointRequest = new HttpRequestMessage
-            {
-                Method = HttpMethod.Get,
-                RequestUri = new Uri(_configuration.Resource, "_api/web/getFolderByServerRelativeUrl('/" + EscapeApostrophe(serverRelativeUrl) + "')"),
-                Headers = { { "Accept", "application/json" } }
-            };
+            var driveId = await GetDriveIdAsync(listTitle);
+            string requestPath = $"drives/{driveId}/{EncodeGraphPath(folderName)}";
 
             using var httpClient = await GetHttpClientAsync();
-            using var response = await httpClient.SendAsync(endpointRequest);
-            string jsonString = await response.Content.ReadAsStringAsync();
+            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Get, requestPath);
 
-            if (response.StatusCode == HttpStatusCode.OK || response.IsSuccessStatusCode)
+            if (response.StatusCode == HttpStatusCode.NotFound)
             {
+                return null;
+            }
+
+            if (response.IsSuccessStatusCode)
+            {
+                string jsonString = await response.Content.ReadAsStringAsync();
                 return JsonConvert.DeserializeObject(jsonString);
             }
 
@@ -323,25 +204,8 @@ namespace Csrs.Interfaces
 
         public async Task<object> GetDocumentLibrary(string listTitle)
         {
-            string title = Uri.EscapeUriString(listTitle);
-
-            using var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Get,
-                RequestUri = new Uri(_configuration.Resource, $"_api/web/lists/GetByTitle('{title}')"),
-                Headers = { { "Accept", "application/json" } }
-            };
-
-            using var httpClient = await GetHttpClientAsync();
-            using var response = await httpClient.SendAsync(request);
-            string jsonString = await response.Content.ReadAsStringAsync();
-
-            if (response.StatusCode == HttpStatusCode.OK)
-            {
-                return JsonConvert.DeserializeObject(jsonString);
-            }
-
-            return null;
+            var list = await GetListAsync(listTitle);
+            return list == null ? null : list.ToObject<object>();
         }
 
         public async Task<string> AddFile(string folderName, string fileName, Stream fileData, string contentType)
@@ -352,11 +216,11 @@ namespace Csrs.Interfaces
         public async Task<string> AddFile(string documentLibrary, string folderName, string fileName, Stream fileData, string contentType)
         {
             folderName = FixFoldername(folderName);
-            bool folderExists = await FolderExists(documentLibrary, folderName);
-            if (!folderExists)
+            if (!await FolderExists(documentLibrary, folderName))
             {
                 await CreateFolder(documentLibrary, folderName);
             }
+
             return await UploadFile(fileName, documentLibrary, folderName, fileData, contentType);
         }
 
@@ -368,11 +232,11 @@ namespace Csrs.Interfaces
         public async Task<string> AddFile(string documentLibrary, string folderName, string fileName, byte[] fileData, string contentType)
         {
             folderName = FixFoldername(folderName);
-            bool folderExists = await FolderExists(documentLibrary, folderName);
-            if (!folderExists)
+            if (!await FolderExists(documentLibrary, folderName))
             {
                 await CreateFolder(documentLibrary, folderName);
             }
+
             return await UploadFile(fileName, documentLibrary, folderName, fileData, contentType);
         }
 
@@ -380,8 +244,7 @@ namespace Csrs.Interfaces
         {
             using var ms = new MemoryStream();
             fileData.CopyTo(ms);
-            byte[] data = ms.ToArray();
-            return await UploadFile(fileName, listTitle, folderName, data, contentType);
+            return await UploadFile(fileName, listTitle, folderName, ms.ToArray(), contentType);
         }
 
         public string GetTruncatedFileName(string fileName, string listTitle, string folderName)
@@ -390,12 +253,12 @@ namespace Csrs.Interfaces
             fileName = FixFilename(fileName, maxLength);
             folderName = FixFoldername(folderName);
 
-            string serverRelativeUrl = GetServerRelativeURL(listTitle, folderName);
-            string requestUriString = GenerateUploadRequestUriString(serverRelativeUrl, fileName);
+            string itemPath = BuildItemPath(folderName, fileName);
+            string requestPath = $"drives/{{driveId}}/{EncodeGraphPath(itemPath)}/content";
 
-            if (requestUriString.Length > MaxUrlLength)
+            if (requestPath.Length > MaxUrlLength)
             {
-                int delta = requestUriString.Length - MaxUrlLength;
+                int delta = requestPath.Length - MaxUrlLength;
                 maxLength -= delta;
                 fileName = FixFilename(fileName, maxLength);
             }
@@ -408,80 +271,64 @@ namespace Csrs.Interfaces
             folderName = FixFoldername(folderName);
             fileName = GetTruncatedFileName(fileName, listTitle, folderName);
 
-            string serverRelativeUrl = GetServerRelativeURL(listTitle, folderName);
-            string requestUriString = GenerateUploadRequestUriString(serverRelativeUrl, fileName);
-
-            using var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Post,
-                RequestUri = new Uri(requestUriString),
-                Headers = { { "Accept", "application/json" } }
-            };
-
-            ByteArrayContent byteArrayContent = new ByteArrayContent(data);
-            byteArrayContent.Headers.Add("content-length", data.Length.ToString());
-            request.Content = byteArrayContent;
+            var driveId = await GetDriveIdAsync(listTitle);
+            string itemPath = BuildItemPath(folderName, fileName);
+            string requestPath = $"drives/{driveId}/{EncodeGraphPath(itemPath)}/content";
 
             using var httpClient = await GetHttpClientAsync();
-            using var response = await httpClient.SendAsync(request);
+            using var request = await CreateGraphRequestAsync(httpClient, HttpMethod.Put, requestPath);
 
-            if (response.StatusCode == HttpStatusCode.OK)
+            var byteArrayContent = new ByteArrayContent(data);
+            byteArrayContent.Headers.ContentType = new MediaTypeHeaderValue(
+                string.IsNullOrWhiteSpace(contentType) ? "application/octet-stream" : contentType);
+            request.Content = byteArrayContent;
+
+            using var response = await httpClient.SendAsync(request);
+            if (response.StatusCode is HttpStatusCode.OK or HttpStatusCode.Created)
             {
                 return fileName;
             }
 
-            var ex = new SharePointRestException($"Operation returned an invalid status code '{response.StatusCode}'");
-            string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            ex.Request = new HttpRequestMessageWrapper(request, null);
-            ex.Response = new HttpResponseMessageWrapper(response, responseContent);
-            throw ex;
+            await ThrowGraphExceptionAsync(response, HttpMethod.Put, requestPath);
+            return fileName;
         }
 
         public async Task<string> UpdateListItemFields(AddFileResponse itemData, string listTitle, string contentType, string fileName)
         {
-            string requestUriString = GenerateUpdateListItemUriString(listTitle, itemData.ListItemAllFields.ID.ToString());
-
-            using var request = new HttpRequestMessage(HttpMethod.Post, requestUriString);
-
-            var listItem = CreateUpdateListItemRequestRequest(contentType, fileName, listTitle);
-            string jsonString = JsonConvert.SerializeObject(listItem);
-            StringContent strContent = new StringContent(jsonString, Encoding.UTF8);
-            strContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json;odata=verbose");
-
-            request.Headers.Add("Accept", "application/json;odata=verbose");
-            request.Headers.Add("X-Http-Method", "MERGE");
-            request.Headers.Add("IF-MATCH", "*");
-            request.Headers.Add("odata-version", "3.0");
-            request.Content = strContent;
-
-            using var httpClient = await GetHttpClientAsync();
-            using var response = await httpClient.SendAsync(request);
-            string streamData = await response.Content.ReadAsStringAsync();
-
-            if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.NoContent)
+            var list = await GetListAsync(listTitle);
+            if (list == null)
             {
-                return streamData;
+                throw new SharePointRestException($"Document library '{listTitle}' was not found.");
             }
 
-            var ex = new SharePointRestException($"Operation returned an invalid status code '{response.StatusCode}'");
-            string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            ex.Request = new HttpRequestMessageWrapper(request, null);
-            ex.Response = new HttpResponseMessageWrapper(response, responseContent);
-            throw ex;
+            string listId = list["id"]?.ToString();
+            string itemId = itemData?.ListItemAllFields?.ID.ToString(CultureInfo.InvariantCulture);
+            if (string.IsNullOrEmpty(itemId))
+            {
+                throw new SharePointRestException("List item id was not provided.");
+            }
+
+            var body = new JObject
+            {
+                ["Title"] = contentType,
+                ["FileLeafRef"] = fileName,
+            };
+
+            string requestPath = $"lists/{listId}/items/{itemId}/fields";
+            using var httpClient = await GetHttpClientAsync();
+            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Patch, requestPath, body);
+            return await ReadSuccessResponseAsync(response, HttpMethod.Patch, requestPath);
         }
 
         public async Task<byte[]> DownloadFile(string url)
         {
-            url = EscapeApostrophe(url);
-
-            using var endpointRequest = new HttpRequestMessage
-            {
-                Method = HttpMethod.Get,
-                RequestUri = new Uri(_configuration.Resource, $"_api/web/GetFileByServerRelativeUrl('{url}')/$value"),
-            };
+            var (libraryName, itemPath) = ParseServerRelativeUrl(url);
+            var driveId = await GetDriveIdAsync(libraryName);
+            string requestPath = $"drives/{driveId}/{EncodeGraphPath(itemPath)}/content";
 
             using var httpClient = await GetHttpClientAsync();
-            using var response = await httpClient.SendAsync(endpointRequest);
+            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Get, requestPath);
+            await EnsureSuccessAsync(response, HttpMethod.Get, requestPath);
 
             using var ms = new MemoryStream();
             await response.Content.CopyToAsync(ms);
@@ -491,59 +338,60 @@ namespace Csrs.Interfaces
         public async Task<bool> DeleteFile(string listTitle, string folderName, string fileName)
         {
             folderName = FixFoldername(folderName);
-            string serverRelativeUrl = $"/{listTitle}/{folderName}/{fileName}";
-            return await DeleteFile(serverRelativeUrl);
+            return await DeleteFile(BuildServerRelativeUrl(listTitle, folderName, fileName));
         }
 
         public async Task<bool> DeleteFile(string serverRelativeUrl)
         {
-            serverRelativeUrl = EscapeApostrophe(serverRelativeUrl);
-
-            using var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Delete,
-                RequestUri = new Uri(_configuration.Resource, $"_api/web/GetFileByServerRelativeUrl('/{serverRelativeUrl}')"),
-                Headers = { { "Accept", "application/json" } }
-            };
-            request.Headers.Add("IF-MATCH", "*");
-            request.Headers.Add("X-HTTP-Method", "DELETE");
+            var (libraryName, itemPath) = ParseServerRelativeUrl(serverRelativeUrl);
+            var driveId = await GetDriveIdAsync(libraryName);
+            string requestPath = $"drives/{driveId}/{EncodeGraphPath(itemPath)}";
 
             using var httpClient = await GetHttpClientAsync();
-            using var response = await httpClient.SendAsync(request);
+            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Delete, requestPath);
 
             if (response.StatusCode == HttpStatusCode.NoContent)
             {
                 return true;
             }
 
-            var ex = new SharePointRestException($"Operation returned an invalid status code '{response.StatusCode}'");
-            string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            ex.Request = new HttpRequestMessageWrapper(request, null);
-            ex.Response = new HttpResponseMessageWrapper(response, responseContent);
-            throw ex;
+            await ThrowGraphExceptionAsync(response, HttpMethod.Delete, requestPath);
+            return false;
         }
 
         public async Task<bool> RenameFile(string oldServerRelativeUrl, string newServerRelativeUrl)
         {
-            oldServerRelativeUrl = EscapeApostrophe(oldServerRelativeUrl);
-            newServerRelativeUrl = EscapeApostrophe(newServerRelativeUrl);
+            var (oldLibrary, oldItemPath) = ParseServerRelativeUrl(oldServerRelativeUrl);
+            var (newLibrary, newItemPath) = ParseServerRelativeUrl(newServerRelativeUrl);
 
-            Uri url = new Uri(_configuration.Resource, $"_api/web/GetFileByServerRelativeUrl('{oldServerRelativeUrl}')/moveto(newurl='{newServerRelativeUrl}', flags=1)");
-            using var request = new HttpRequestMessage(HttpMethod.Post, url);
+            if (!string.Equals(oldLibrary, newLibrary, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new SharePointRestException("Renaming files across document libraries is not supported.");
+            }
+
+            string newFileName = Path.GetFileName(newItemPath.Replace('/', Path.DirectorySeparatorChar));
+            var driveId = await GetDriveIdAsync(oldLibrary);
+            string requestPath = $"drives/{driveId}/{EncodeGraphPath(oldItemPath)}";
 
             using var httpClient = await GetHttpClientAsync();
-            using var response = await httpClient.SendAsync(request);
+            using var getResponse = await SendGraphRequestAsync(httpClient, HttpMethod.Get, requestPath);
+            string itemJson = await ReadSuccessResponseAsync(getResponse, HttpMethod.Get, requestPath);
+            string itemId = JObject.Parse(itemJson)["id"]?.ToString();
 
-            if (response.StatusCode == HttpStatusCode.OK)
+            var body = new JObject { ["name"] = newFileName };
+            using var patchResponse = await SendGraphRequestAsync(
+                httpClient,
+                HttpMethod.Patch,
+                $"drives/{driveId}/items/{itemId}",
+                body);
+
+            if (patchResponse.IsSuccessStatusCode)
             {
                 return true;
             }
 
-            var ex = new SharePointRestException($"Operation returned an invalid status code '{response.StatusCode}'");
-            string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            ex.Request = new HttpRequestMessageWrapper(request, null);
-            ex.Response = new HttpResponseMessageWrapper(response, responseContent);
-            throw ex;
+            await ThrowGraphExceptionAsync(patchResponse, HttpMethod.Patch, $"drives/{driveId}/items/{itemId}");
+            return false;
         }
 
         private async Task<HttpClient> GetHttpClientAsync()
@@ -552,79 +400,252 @@ namespace Csrs.Interfaces
             HttpMessageHandler handler = new SocketsHttpHandler
             {
                 AllowAutoRedirect = false,
-                MaxConnectionsPerServer = 25
+                MaxConnectionsPerServer = 25,
             };
 #pragma warning restore CA2000
 
-            HttpClient httpClient = new HttpClient(handler);
-            httpClient.BaseAddress = _configuration.Resource;
-            httpClient.DefaultRequestHeaders.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata=verbose"));
+            var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = _configuration.GraphBaseUri,
+            };
+            httpClient.DefaultRequestHeaders.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
             string accessToken = await _authenticator.GetAccessTokenAsync();
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
-            string digest = await GetDigest(httpClient);
-            if (digest is not null)
-            {
-                httpClient.DefaultRequestHeaders.Add("X-RequestDigest", digest);
-            }
-
-            httpClient.DefaultRequestHeaders.Add("Cache-Control", "no-cache");
-            httpClient.DefaultRequestHeaders.Add("OData-Version", "4.0");
-
             return httpClient;
         }
 
-        private async Task<string> GetDigest(HttpClient client)
+        private async Task<string> GetSiteIdAsync()
         {
-            string result = null;
-
-            using var endpointRequest = new HttpRequestMessage
+            if (!string.IsNullOrEmpty(_siteId))
             {
-                Method = HttpMethod.Post,
-                RequestUri = new Uri(_configuration.Resource, "_api/contextinfo"),
-                Headers = { { "Accept", "application/json;odata=verbose" } }
-            };
-
-            var response = await client.SendAsync(endpointRequest);
-            string jsonString = await response.Content.ReadAsStringAsync();
-
-            if (response.StatusCode == HttpStatusCode.OK && jsonString.Length > 1)
-            {
-                if (jsonString[0] == '{')
-                {
-                    JToken t = JToken.Parse(jsonString);
-                    result = t["d"]["GetContextWebInformation"]["FormDigestValue"].ToString();
-                }
-                else
-                {
-                    XmlDocument doc = new XmlDocument();
-                    doc.LoadXml(jsonString);
-                    var digests = doc.GetElementsByTagName("d:FormDigestValue");
-                    if (digests.Count > 0)
-                    {
-                        result = digests[0].InnerText;
-                    }
-                }
+                return _siteId;
             }
 
-            return result;
+            var resourceUri = _configuration.Resource;
+            string sitePath = resourceUri.AbsolutePath.TrimEnd('/');
+            if (string.IsNullOrEmpty(sitePath))
+            {
+                sitePath = "/";
+            }
+
+            string requestPath = $"sites/{resourceUri.Host}:{sitePath}";
+            using var httpClient = await GetHttpClientAsync();
+            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Get, requestPath);
+            string responseContent = await ReadSuccessResponseAsync(response, HttpMethod.Get, requestPath);
+            _siteId = JObject.Parse(responseContent)["id"]?.ToString();
+
+            if (string.IsNullOrEmpty(_siteId))
+            {
+                throw new SharePointRestException("Unable to resolve SharePoint site id from Microsoft Graph.");
+            }
+
+            return _siteId;
         }
 
-        private static string EscapeApostrophe(string value)
+        private async Task<JToken> GetListAsync(string listTitle)
         {
-            if (!string.IsNullOrEmpty(value))
+            string siteId = await GetSiteIdAsync();
+            using var httpClient = await GetHttpClientAsync();
+            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Get, "lists?$select=id,name,displayName,list");
+            string responseContent = await ReadSuccessResponseAsync(response, HttpMethod.Get, "lists");
+
+            foreach (var list in ParseGraphCollection(responseContent))
             {
-                return value.Replace("'", "''");
+                if (list["list"]?["template"]?.ToString() != "documentLibrary")
+                {
+                    continue;
+                }
+
+                if (MatchesListTitle(list, listTitle))
+                {
+                    return list;
+                }
             }
-            return value;
+
+            return null;
+        }
+
+        private async Task<string> GetDriveIdAsync(string listTitle)
+        {
+            if (_driveIdCache.TryGetValue(listTitle, out string cachedDriveId))
+            {
+                return cachedDriveId;
+            }
+
+            var list = await GetListAsync(listTitle);
+            if (list == null)
+            {
+                throw new SharePointRestException($"Document library '{listTitle}' was not found.");
+            }
+
+            string listId = list["id"]?.ToString();
+            using var httpClient = await GetHttpClientAsync();
+            using var response = await SendGraphRequestAsync(httpClient, HttpMethod.Get, $"lists/{listId}/drive");
+            string responseContent = await ReadSuccessResponseAsync(response, HttpMethod.Get, $"lists/{listId}/drive");
+            string driveId = JObject.Parse(responseContent)["id"]?.ToString();
+
+            if (string.IsNullOrEmpty(driveId))
+            {
+                throw new SharePointRestException($"Unable to resolve drive id for document library '{listTitle}'.");
+            }
+
+            _driveIdCache[listTitle] = driveId;
+            return driveId;
+        }
+
+        private static bool MatchesListTitle(JToken list, string listTitle)
+        {
+            return string.Equals(list["name"]?.ToString(), listTitle, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(list["displayName"]?.ToString(), listTitle, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private async Task<HttpRequestMessage> CreateGraphRequestAsync(HttpClient httpClient, HttpMethod method, string relativePath)
+        {
+            string siteId = await GetSiteIdAsync();
+            var request = new HttpRequestMessage(method, $"sites/{siteId}/{relativePath}");
+            return request;
+        }
+
+        private async Task<HttpResponseMessage> SendGraphRequestAsync(
+            HttpClient httpClient,
+            HttpMethod method,
+            string relativePath,
+            JObject body = null)
+        {
+            var request = await CreateGraphRequestAsync(httpClient, method, relativePath);
+            if (body != null)
+            {
+                request.Content = new StringContent(body.ToString(Formatting.None), Encoding.UTF8, "application/json");
+            }
+
+            return await httpClient.SendAsync(request);
+        }
+
+        private static List<JToken> ParseGraphCollection(string responseContent)
+        {
+            var responseObject = JObject.Parse(responseContent);
+            if (responseObject["value"] is JArray values)
+            {
+                return values.Children().ToList();
+            }
+
+            return new List<JToken>();
+        }
+
+        private async Task<string> ReadSuccessResponseAsync(
+            HttpResponseMessage response,
+            HttpMethod method,
+            string relativePath,
+            HttpStatusCode? expectedStatusCode = null)
+        {
+            await EnsureSuccessAsync(response, method, relativePath, expectedStatusCode);
+            return response.Content == null ? string.Empty : await response.Content.ReadAsStringAsync();
+        }
+
+        private async Task EnsureSuccessAsync(
+            HttpResponseMessage response,
+            HttpMethod method,
+            string relativePath,
+            HttpStatusCode? expectedStatusCode = null)
+        {
+            if (expectedStatusCode.HasValue && response.StatusCode == expectedStatusCode.Value)
+            {
+                return;
+            }
+
+            if (response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            await ThrowGraphExceptionAsync(response, method, relativePath);
+        }
+
+        private async Task ThrowGraphExceptionAsync(HttpResponseMessage response, HttpMethod method, string relativePath)
+        {
+            string responseContent = response.Content == null
+                ? string.Empty
+                : await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            var ex = new SharePointRestException(
+                $"Microsoft Graph operation returned an invalid status code '{response.StatusCode}'");
+            ex.Request = new HttpRequestMessageWrapper(new HttpRequestMessage(method, relativePath), null);
+            ex.Response = new HttpResponseMessageWrapper(response, responseContent);
+            throw ex;
+        }
+
+        private string GetSiteServerRelativePath()
+        {
+            return _configuration.Resource.AbsolutePath.TrimEnd('/');
+        }
+
+        private string BuildServerRelativeUrl(string listTitle, string folderName, string fileName)
+        {
+            string path = $"{GetSiteServerRelativePath()}/{listTitle}";
+            if (!string.IsNullOrEmpty(folderName))
+            {
+                path += $"/{folderName}";
+            }
+
+            if (!string.IsNullOrEmpty(fileName))
+            {
+                path += $"/{fileName}";
+            }
+
+            return path;
+        }
+
+        private (string LibraryName, string ItemPath) ParseServerRelativeUrl(string serverRelativeUrl)
+        {
+            string normalizedUrl = serverRelativeUrl.Trim().TrimStart('/');
+            string sitePath = GetSiteServerRelativePath().TrimStart('/');
+
+            if (normalizedUrl.StartsWith(sitePath, StringComparison.OrdinalIgnoreCase))
+            {
+                normalizedUrl = normalizedUrl.Substring(sitePath.Length).TrimStart('/');
+            }
+
+            int separatorIndex = normalizedUrl.IndexOf('/');
+            if (separatorIndex < 0)
+            {
+                return (normalizedUrl, string.Empty);
+            }
+
+            string libraryName = normalizedUrl.Substring(0, separatorIndex);
+            string itemPath = normalizedUrl.Substring(separatorIndex + 1);
+            return (libraryName, itemPath);
+        }
+
+        private static string BuildItemPath(string folderName, string fileName)
+        {
+            if (string.IsNullOrEmpty(folderName))
+            {
+                return fileName;
+            }
+
+            return $"{folderName}/{fileName}";
+        }
+
+        private static string EncodeGraphPath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return "root";
+            }
+
+            var encodedSegments = path
+                .Split('/', StringSplitOptions.RemoveEmptyEntries)
+                .Select(Uri.EscapeDataString);
+            return $"root:/{string.Join("/", encodedSegments)}:";
         }
 
         private string GetInvalidCharacters(string osInvalidChars)
         {
             osInvalidChars += "~#%&*()[]{}:;+@^<>|.?!/";
             string invalidChars = Regex.Escape(osInvalidChars);
-            return string.Format(@"([{0}]*\.+$)|([{0}]+)", invalidChars);
+            return string.Format(CultureInfo.InvariantCulture, @"([{0}]*\.+$)|([{0}]+)", invalidChars);
         }
 
         private string RemoveInvalidCharacters(string filename)
@@ -648,51 +669,8 @@ namespace Csrs.Interfaces
                 result = Path.GetFileNameWithoutExtension(result).Substring(0, maxLength - extension.Length);
                 result += extension;
             }
+
             return result;
-        }
-
-        private string GetServerRelativeURL(string listTitle, string folderName)
-        {
-            folderName = FixFoldername(folderName);
-            return Uri.EscapeUriString(listTitle) + "/" + Uri.EscapeUriString(folderName);
-        }
-
-        private string GenerateUploadRequestUriString(string folderServerRelativeUrl, string fileName)
-        {
-            folderServerRelativeUrl = EscapeApostrophe(folderServerRelativeUrl);
-            fileName = EscapeApostrophe(fileName);
-            Uri requestUri = new Uri(_configuration.Resource, $"_api/web/getFolderByServerRelativeUrl('/{folderServerRelativeUrl}')/Files/add(url='{fileName}',overwrite=true)?$expand=ListItemAllFields");
-            return requestUri.ToString();
-        }
-
-        private string GenerateUpdateListItemUriString(string listTitle, string id)
-        {
-            listTitle = EscapeApostrophe(listTitle);
-            id = EscapeApostrophe(id);
-            Uri requestUri = new Uri(_configuration.Resource, $"_api/web/lists/getbytitle('{listTitle}')/items({id})");
-            return requestUri.ToString();
-        }
-
-        private static object CreateNewDocumentLibraryRequest(string listName)
-        {
-            return new
-            {
-                __metadata = new { type = "SP.List" },
-                BaseTemplate = 101,
-                Title = listName
-            };
-        }
-
-        private static object CreateUpdateListItemRequestRequest(string title, string fileName, string listTitle)
-        {
-            string formattedTitle = listTitle.Replace(" ", SharePointSpaceCharacter);
-            string itemType = $"SP.Data.{formattedTitle}Item";
-            return new
-            {
-                __metadata = new { type = itemType },
-                FileLeafRef = fileName,
-                Title = title
-            };
         }
     }
 }

--- a/src/backend/Csrs.Services.FileManager/Program.cs
+++ b/src/backend/Csrs.Services.FileManager/Program.cs
@@ -59,9 +59,9 @@ namespace Csrs.Services.FileManager
                 Serilog.Debugging.SelfLog.Enable(Console.Error);
             });
 
-            
 
-            builder.Services.AddSharePointIntegration();
+
+            builder.Services.AddSharePointIntegration(builder.Configuration);
 
             builder.Services.AddGrpc(options =>
             {
@@ -104,13 +104,13 @@ namespace Csrs.Services.FileManager
 
         }
     }
-    
+
     internal static class BuildInfo
     {
-    #if GIT_COMMIT
+#if GIT_COMMIT
         public const string GitCommitId = GIT_COMMIT;
-    #else
+#else
         public const string GitCommitId = "unknown";
-    #endif
+#endif
     }
 }

--- a/src/backend/Csrs.Services.FileManager/Services/FileManagerService.cs
+++ b/src/backend/Csrs.Services.FileManager/Services/FileManagerService.cs
@@ -13,10 +13,10 @@ namespace Csrs.Services.FileManager
 {
     public class FileManagerService : FileManager.FileManagerBase
     {
-        private readonly SharePointFileManager _sharePointFileManager;
+        private readonly ISharePointFileManager _sharePointFileManager;
         private readonly ILogger<FileManagerService> _logger;
 
-        public FileManagerService(SharePointFileManager sharePointFileManager, ILogger<FileManagerService> logger)
+        public FileManagerService(ISharePointFileManager sharePointFileManager, ILogger<FileManagerService> logger)
         {
             _sharePointFileManager = sharePointFileManager ?? throw new ArgumentNullException(nameof(sharePointFileManager));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/src/frontend/csrs-portal/package.json
+++ b/src/frontend/csrs-portal/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "configure": "ts-node setenv.ts",
     "start": "yarn run configure -- --environment=dev && ng serve",
+    "start-npm-proxy": "npm run configure -- --environment=dev && ng serve --proxy-config proxy.conf.json",
     "start-proxy": "yarn run configure -- --environment=dev && ng serve --proxy-config proxy.conf.json",
     "build-dev": "yarn run configure -- --environment=dev && ng build --source-map=false",
     "build-prod": "yarn run configure -- --environment=prod && ng build --configuration production --source-map=false",


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

This pull request introduces a contingency mode for SharePoint Online integration, allowing the application to switch between on-premises SharePoint (SAML) and SharePoint Online (OAuth2/Microsoft Graph) for document storage. It includes new configuration parameters, dependency injection changes, new interfaces and classes for SharePoint Online authentication, and updates to support this dual-mode operation. The changes are grouped below by theme.

**SharePoint Online Contingency Mode & Configuration:**

* Added new configuration parameters (`USE_SHAREPOINT_ONLINE_CONTINGENCY`, `SPO_TENANT_ID`, `SPO_CLIENT_ID`, `SPO_RESOURCE`, etc.) to `openshift/jag-csrs-file-manager.yml` for enabling and configuring SharePoint Online integration.
* Updated deployment environment variables and secret references to pass SharePoint Online configuration to the backend when contingency mode is enabled.

**Dependency Injection & Service Registration:**

* Refactored `AddSharePointIntegration` to accept configuration and register either the on-premises or SharePoint Online implementation of `ISharePointFileManager` based on the contingency flag. Registers new services for SharePoint Online authentication when enabled. [[1]](diffhunk://#diff-6ada0e3f90e174adfc77918a80998a61519e7572b7ef17fd66b296e51d6b601eL10-R37) [[2]](diffhunk://#diff-6ada0e3f90e174adfc77918a80998a61519e7572b7ef17fd66b296e51d6b601eR59-R85) [[3]](diffhunk://#diff-da5be0274bae97453e9cd0f774609d5ba6e4d2ad43037ccefc1104bd3b9766d7L64-R64)

**SharePoint Online Support - Interfaces & Implementation:**

* Introduced `ISharePointFileManager` interface and updated `SharePointFileManager` to implement it, enabling polymorphic use of either on-premises or online managers. [[1]](diffhunk://#diff-178675810f7089e779c95e548803244c198f4e108f8b43be75148dc2125d1354R1-R51) [[2]](diffhunk://#diff-174de234dd75ea1509806f6414d794e50be93268d70a3211300b26e6d74973e3L23-R23) [[3]](diffhunk://#diff-d4c946abcf5331bad442da655f74a965842badb40ca30ea6b955ca5cc036f15cL16-R19)
* Added `ISharePointOnlineAuthenticator` interface and its implementation `SharePointOnlineAuthenticator` to acquire and cache Microsoft Graph OAuth2 tokens. [[1]](diffhunk://#diff-5c40cdc411c290166c38cf3d6a54212041c5a39569d7b48f977abe15548be6d4R1-R13) [[2]](diffhunk://#diff-3448081a06c73b2545abf4527565e0b65ba5da6c5bb1dfb73d26cb25bb6ceb58R1-R96)
* Added `SharePointOnlineConfiguration` class to encapsulate SharePoint Online connection settings.

**Other Improvements:**

* Added a missing AppContext switch to allow unencrypted HTTP/2 (h2c) for gRPC when running insecurely in .NET 6.
* Added a new frontend npm script for starting the Angular app with a proxy using npm.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
