### PR TITLE
Update timezone handling to rely on UTC to avoid timezone change issues

### DIFF
--- a/src/backend/Csrs.Api/Extensions/FileSystemItemExtensions.cs
+++ b/src/backend/Csrs.Api/Extensions/FileSystemItemExtensions.cs
@@ -38,11 +38,11 @@
         public static string CombineNameDocumentType(string name, string documentType)
         {
             int idx = name.IndexOf(".");
-            if(idx > -1)
+            if (idx > -1)
             {
                 string tmp = name.Substring(0, idx);
                 string ext = System.IO.Path.GetExtension(name);
-                name = tmp + DateTime.Now.ToString("_yyyyMMddhhmmss")+ ext;
+                name = tmp + DateTime.UtcNow.ToString("_yyyyMMddHHmmss") + ext;
             }
             string result = documentType + NameDocumentTypeSeparator + name;
             return result;

--- a/src/backend/Csrs.Api/Features/Accounts/UpdateCSRSAccount.cs
+++ b/src/backend/Csrs.Api/Features/Accounts/UpdateCSRSAccount.cs
@@ -97,7 +97,7 @@ namespace Csrs.Api.Features.Accounts
                 var fullName = parties?.Value[0].SsgFullname;
 
                 task.Subject = $"File {file.SsgFilenumber} - Account Setup Submitted";
-                task.Description = $"Respondent Application submitted, please review.\nParty: {fullName}"; 
+                task.Description = $"Respondent Application submitted, please review.\nParty: {fullName}";
                 task.Isregularactivity = true;
 
                 var owninguser = file._owninguserValue;
@@ -110,12 +110,12 @@ namespace Csrs.Api.Features.Accounts
 
                 task.Prioritycode = 1;// Normal
                 task.Statuscode = 2; // Not Started
-                task.Scheduledend = new DateTimeOffset(DateTime.UtcNow);
+                task.Scheduledend = DateTimeOffset.UtcNow;
 
                 try
                 {
                     MicrosoftDynamicsCRMtask result = await _dynamicsClient.Tasks.CreateAsync(task);
-                } 
+                }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "An exception occurred while creating task with partyId = {PartyId} and fileid = {FileId},  CSRS account file update will be aborted", partyId, fileId);

--- a/src/backend/Csrs.Api/Models/ModelExtensions.cs
+++ b/src/backend/Csrs.Api/Models/ModelExtensions.cs
@@ -149,7 +149,7 @@ namespace Csrs.Api.Models
                 SsgPartyenrolled = GetPartyEnrolled(file.PartyEnrolled),
 
                 SsgRecalculationorderedbythecourt = ConvertToBool(file.RecalculationOrderByCourt),
-                SsgSubmissiondate = new DateTimeOffset(DateTime.Now)
+                SsgSubmissiondate = DateTimeOffset.UtcNow
 
                 //SsgSharedparenting = true; ???
                 //SsgSplitparentingarrangement = true; ??

--- a/src/backend/Csrs.Services.FileManager/OpenShiftIntegration/OpenShiftCertificateExpiration.cs
+++ b/src/backend/Csrs.Services.FileManager/OpenShiftIntegration/OpenShiftCertificateExpiration.cs
@@ -21,7 +21,7 @@ namespace Csrs.Services.FileManager.OpenShiftIntegration
 
         public OpenShiftCertificateExpiration(
             IOptions<OpenShiftIntegrationOptions> options,
-            OpenShiftCertificateLoader certificateLoader, 
+            OpenShiftCertificateLoader certificateLoader,
             IHostApplicationLifetime applicationLifetime,
             ILogger<OpenShiftCertificateExpiration> logger)
         {
@@ -46,11 +46,11 @@ namespace Csrs.Services.FileManager.OpenShiftIntegration
                     _logger.LogDebug("Certificate expires at {CertificateExpiration}", certificate.NotAfter.ToUniversalTime());
 
                     // will loop if the number of milliseconds to sleep is greater than int.MaxValue (24.8 days)
-                    bool loop; 
+                    bool loop;
                     {
                         loop = false;
-                        var expiresAt = certificate.NotAfter - NotAfterMargin; // NotAfter is in local time.
-                        var tillExpires = expiresAt - DateTime.Now;
+                        var expiresAt = certificate.NotAfter.ToUniversalTime() - NotAfterMargin; // Use UTC to avoid DST ambiguity.
+                        var tillExpires = expiresAt - DateTime.UtcNow;
                         if (tillExpires > TimeSpan.Zero)
                         {
                             if (tillExpires > RestartSpan)


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- {List all the changes, if possible add the jira ticket #}

This pull request standardizes the use of UTC time across the codebase to avoid issues related to local time zones and daylight saving time, ensuring consistency and reliability in time-related operations.

**Time Handling Improvements:**

* Replaced `DateTime.Now` with `DateTime.UtcNow` for generating timestamps when combining document names in `FileSystemItemExtensions.cs` to ensure time consistency across different environments.
* Updated task scheduling in `UpdateCSRSAccount.cs` to use `DateTimeOffset.UtcNow` instead of constructing a new offset from `DateTime.UtcNow`, improving clarity and correctness.
* Changed file submission date assignment in `ModelExtensions.cs` from `DateTime.Now` to `DateTimeOffset.UtcNow` for accurate UTC timestamping.
* Modified certificate expiration calculations in `OpenShiftCertificateExpiration.cs` to use UTC (`ToUniversalTime` and `DateTime.UtcNow`) instead of local time, preventing errors due to daylight saving time changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
